### PR TITLE
feat(link): include size property

### DIFF
--- a/packages/ocean-core/src/components/_link.scss
+++ b/packages/ocean-core/src/components/_link.scss
@@ -2,7 +2,6 @@
   color: $color-brand-primary-pure;
   cursor: pointer;
   font-family: $font-family-base;
-  font-size: $font-size-xs;
   font-weight: $font-weight-regular;
   line-height: $line-height-tight;
 
@@ -17,5 +16,13 @@
     &:hover {
       color: $color-complementary-up;
     }
+  }
+
+  &--sm {
+    font-size: $font-size-xxs;
+  }
+
+  &--md {
+    font-size: $font-size-xs;
   }
 }

--- a/packages/ocean-react/src/Link/Link.tsx
+++ b/packages/ocean-react/src/Link/Link.tsx
@@ -17,11 +17,23 @@ export type LinkProps<P extends React.ElementType = 'a'> = {
      * @default 'false'
      */
     inverse?: boolean;
+    /**
+     * The size of the link.
+     * @default 'md'
+     */
+    size?: 'sm' | 'md';
   }
 >;
 
 function LinkBase<T extends React.ElementType = 'a'>(
-  { children, className, inverse, component, ...rest }: LinkProps<T>,
+  {
+    children,
+    className,
+    inverse,
+    size = 'md',
+    component,
+    ...rest
+  }: LinkProps<T>,
   ref: React.Ref<HTMLLinkElement>
 ) {
   return React.createElement(
@@ -30,6 +42,7 @@ function LinkBase<T extends React.ElementType = 'a'>(
       ref,
       className: classNames(
         'ods-lnk',
+        `ods-lnk--${size}`,
         inverse && 'ods-lnk--inverse',
         className
       ),
@@ -39,6 +52,6 @@ function LinkBase<T extends React.ElementType = 'a'>(
   );
 }
 
-const Link = (React.forwardRef(LinkBase) as unknown) as typeof LinkBase;
+const Link = React.forwardRef(LinkBase) as unknown as typeof LinkBase;
 
 export default Link;

--- a/packages/ocean-react/src/Link/__tests__/Link.test.tsx
+++ b/packages/ocean-react/src/Link/__tests__/Link.test.tsx
@@ -13,13 +13,14 @@ test('renders element properly', () => {
 
   expect(screen.getByTestId('lnk-test')).toMatchInlineSnapshot(`
     <a
-      class="ods-lnk custom-class"
+      class="ods-lnk ods-lnk--md custom-class"
       data-testid="lnk-test"
     >
       Click here!
     </a>
   `);
 });
+
 test('renders an inverse link', () => {
   render(<Link data-testid="lnk-test" inverse />);
   expect(screen.getByTestId('lnk-test')).toHaveClass('ods-lnk--inverse');
@@ -36,11 +37,21 @@ test('renders a link with router', () => {
 
   expect(screen.getByTestId('lnk-test')).toMatchInlineSnapshot(`
     <a
-      class="ods-lnk"
+      class="ods-lnk ods-lnk--md"
       data-testid="lnk-test"
       href="/teste/1234"
     >
       Link
     </a>
   `);
+});
+
+test('renders a small link', () => {
+  render(<Link data-testid="lnk-test" size="sm" />);
+  expect(screen.getByTestId('lnk-test')).toHaveClass('ods-lnk--sm');
+});
+
+test('renders a medium link', () => {
+  render(<Link data-testid="lnk-test" size="md" />);
+  expect(screen.getByTestId('lnk-test')).toHaveClass('ods-lnk--md');
 });

--- a/packages/ocean-react/src/Link/stories/Link.stories.mdx
+++ b/packages/ocean-react/src/Link/stories/Link.stories.mdx
@@ -38,6 +38,22 @@ import Link from '../Link';
         type: null,
       },
     },
+    size: {
+      name: 'size',
+      description: 'The size of the link.',
+      defaultValue: 'md',
+      table: {
+        type: {
+          summary: '"sm" | "md"',
+        },
+        defaultValue: {
+          summary: 'md',
+        },
+      },
+      control: {
+        type: null,
+      },
+    },
   }}
 />
 
@@ -73,6 +89,7 @@ Any other props supplied will be provided to the root element (native element).
 | ----------------- | -------------------------------------- |
 | .ods-lnk          | Styles applied to the root element.    |
 | .ods-lnk--inverse | Use the inverse a on dark backgrounds. |
+| .ods-lnk--[sm,md] | Specifies the font size of the link.   |
 
 If that's not sufficient, you can check the [implementation of the component](https://github.com/ocean-ds/ocean-web/blob/master/packages/ocean-react/src/Link/Link.tsx) for more detail.
 
@@ -84,6 +101,7 @@ If that's not sufficient, you can check the [implementation of the component](ht
     args={{
       children: 'My Link',
       inverse: false,
+      size: 'md',
     }}
     argTypes={{
       children: {
@@ -93,6 +111,13 @@ If that's not sufficient, you can check the [implementation of the component](ht
       inverse: {
         name: 'inverse',
         control: 'boolean',
+      },
+      size: {
+        name: 'size',
+        control: {
+          type: 'select',
+          options: ['sm', 'md'],
+        },
       },
     }}
   >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Includes a size prop in the Link component.

Fixes #760 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

https://ocean-ds.github.io/ocean-web/?path=/story/components-link--playground

## Screenshots (if appropriate):

![Peek 2021-08-11 09-52](https://user-images.githubusercontent.com/3240432/129031958-f96dfae6-6d1d-4096-9380-550ffe539eb6.gif)

## Checklist:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] My changes work in Chrome, Edge, and Firefox
- [x] I have made corresponding changes to the documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed
