### PR TITLE
feat: add alert component

### DIFF
--- a/packages/ocean-core/src/components/_alert.scss
+++ b/packages/ocean-core/src/components/_alert.scss
@@ -1,0 +1,74 @@
+.ods-alert {
+  align-items: center;
+  background-color: $color-interface-light-up;
+  border-radius: $border-radius-md;
+  color: $color-interface-dark-down;
+  display: flex;
+  font-family: $font-family-base;
+  font-size: $font-size-xxxs;
+  font-weight: $font-weight-regular;
+  justify-content: left;
+  line-height: $line-height-comfy;
+  padding: $spacing-stack-xs;
+
+  &--error {
+    background-color: $color-status-negative-up;
+
+    .ods-alert__icon {
+      stroke: $color-status-negative-pure;
+    }
+
+    .ods-alert__title {
+      color: $color-status-negative-pure;
+    }
+  }
+
+  &--warning {
+    background-color: $color-status-neutral-up;
+
+    .ods-alert__icon {
+      stroke: $color-status-neutral-deep;
+    }
+
+    .ods-alert__title {
+      color: $color-status-neutral-deep;
+    }
+  }
+
+  &--success {
+    background-color: $color-status-positive-up;
+
+    .ods-alert__icon {
+      stroke: $color-status-positive-deep;
+    }
+
+    .ods-alert__title {
+      color: $color-status-positive-deep;
+    }
+  }
+
+  &--has-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  &__icon {
+    margin-right: 8px;
+    min-width: $spacing-stack-sm;
+    stroke: $color-brand-primary-down;
+  }
+
+  &__header {
+    align-items: center;
+    display: flex;
+    margin: 0 0 $spacing-stack-xxs 0;
+    width: 100%;
+  }
+
+  &__title {
+    color: $color-brand-primary-down;
+    font-size: $font-size-xxs;
+    font-weight: $font-weight-bold;
+    line-height: $line-height-comfy;
+  }
+}

--- a/packages/ocean-core/src/components/_all.scss
+++ b/packages/ocean-core/src/components/_all.scss
@@ -1,4 +1,5 @@
 @import 'typography';
+@import 'alert';
 @import 'divider';
 @import 'button';
 @import 'icon-button';

--- a/packages/ocean-react/src/Alert/Alert.tsx
+++ b/packages/ocean-react/src/Alert/Alert.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import classNames from 'classnames';
+
+import AlertIcon from './AlertIcon';
+
+export type AlertProps = {
+  /**
+   * Determines the type of alert, with default icon and colors for each type
+   * @default 'default'
+   */
+  type?: 'success' | 'warning' | 'error' | 'default';
+  /**
+   * Sets a title for the Alert
+   */
+  title?: string;
+  /**
+   * Sets a custon icon for the Alert.
+   */
+  icon?: React.ReactNode;
+} & React.ComponentPropsWithoutRef<'div'>;
+
+const Alert = React.forwardRef<HTMLDivElement, AlertProps>(function Alert(
+  { children, type = 'default', title, className, icon, ...rest },
+  ref
+) {
+  const alertIcon = (
+    <AlertIcon type={type} icon={icon} className="ods-alert__icon" />
+  );
+
+  return (
+    <div
+      ref={ref}
+      role="alert"
+      className={classNames(
+        'ods-alert',
+        `ods-alert--${type}`,
+        title && 'ods-alert--has-header',
+        className
+      )}
+      {...rest}
+    >
+      {title ? (
+        <div className="ods-alert__header">
+          {alertIcon}
+          <div className="ods-alert__title">{title}</div>
+        </div>
+      ) : (
+        alertIcon
+      )}
+
+      {children}
+    </div>
+  );
+});
+
+export default Alert;

--- a/packages/ocean-react/src/Alert/AlertIcon.tsx
+++ b/packages/ocean-react/src/Alert/AlertIcon.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import {
+  XCircleOutline,
+  InformationCircleOutline,
+  ExclamationCircleOutline,
+  CheckCircleOutline,
+} from '@useblu/ocean-icons-react';
+
+export type AlertIconProps = {
+  /**
+   * Determines the type of alert, with default icon and colors for each type
+   */
+  type: 'success' | 'warning' | 'error' | 'default';
+  /**
+   * Sets a title for the Alert
+   */
+  icon?: React.ReactNode;
+} & React.ComponentPropsWithoutRef<'div'>;
+
+const mapIconsByType = {
+  warning: ExclamationCircleOutline,
+  error: XCircleOutline,
+  success: CheckCircleOutline,
+  default: InformationCircleOutline,
+};
+
+const AlertIcon = React.memo<AlertIconProps>(function AlertIcon({
+  type,
+  icon,
+}) {
+  const IconEl = mapIconsByType[type];
+
+  if (icon) return <div className="ods-alert__icon">{icon}</div>;
+
+  return (
+    <IconEl
+      size={24}
+      className="ods-alert__icon"
+      aria-hidden
+      focusable={false}
+    />
+  );
+});
+
+export default AlertIcon;

--- a/packages/ocean-react/src/Alert/__tests__/Alert.test.tsx
+++ b/packages/ocean-react/src/Alert/__tests__/Alert.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { StarOutline } from '@useblu/ocean-icons-react';
+
+import Alert, { AlertProps } from '../Alert';
+
+jest.mock('@useblu/ocean-icons-react', () => ({
+  InformationCircleOutline: () => 'mock-information-circle-outline',
+  ExclamationCircleOutline: () => 'mock-exclamation-circle-outline',
+  XCircleOutline: () => 'mock-x-circle-outline',
+  CheckCircleOutline: () => 'mock-check-circle-outline',
+  StarOutline: () => 'mock-start-outline',
+}));
+
+const setup = (props?: AlertProps) => {
+  render(<Alert {...props}>Hello There!</Alert>);
+};
+
+test('renders default element properly', () => {
+  setup();
+
+  expect(document.querySelector('.ods-alert')).toMatchInlineSnapshot(`
+    <div
+      class="ods-alert ods-alert--default"
+      role="alert"
+    >
+      mock-information-circle-outline
+      Hello There!
+    </div>
+  `);
+});
+
+test('renders success element properly', () => {
+  setup({ type: 'success' });
+
+  expect(document.querySelector('.ods-alert')).toMatchInlineSnapshot(`
+    <div
+      class="ods-alert ods-alert--success"
+      role="alert"
+    >
+      mock-check-circle-outline
+      Hello There!
+    </div>
+  `);
+});
+
+test('renders error element properly', () => {
+  setup({ type: 'error' });
+
+  expect(document.querySelector('.ods-alert')).toMatchInlineSnapshot(`
+    <div
+      class="ods-alert ods-alert--error"
+      role="alert"
+    >
+      mock-x-circle-outline
+      Hello There!
+    </div>
+  `);
+});
+
+test('renders element with a custom icon', () => {
+  setup({ icon: <StarOutline /> });
+
+  expect(document.querySelector('.ods-alert')).toMatchInlineSnapshot(`
+    <div
+      class="ods-alert ods-alert--default"
+      role="alert"
+    >
+      <div
+        class="ods-alert__icon"
+      >
+        mock-start-outline
+      </div>
+      Hello There!
+    </div>
+  `);
+});
+
+test('renders warning element properly', () => {
+  setup({ type: 'warning' });
+
+  expect(document.querySelector('.ods-alert')).toMatchInlineSnapshot(`
+    <div
+      class="ods-alert ods-alert--warning"
+      role="alert"
+    >
+      mock-exclamation-circle-outline
+      Hello There!
+    </div>
+  `);
+});
+
+test('renders element properly with title', () => {
+  setup({ title: "Test's Title" });
+
+  expect(document.querySelector('.ods-alert')).toMatchInlineSnapshot(`
+    <div
+      class="ods-alert ods-alert--default ods-alert--has-header"
+      role="alert"
+    >
+      <div
+        class="ods-alert__header"
+      >
+        mock-information-circle-outline
+        <div
+          class="ods-alert__title"
+        >
+          Test's Title
+        </div>
+      </div>
+      Hello There!
+    </div>
+  `);
+});

--- a/packages/ocean-react/src/Alert/index.ts
+++ b/packages/ocean-react/src/Alert/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Alert';

--- a/packages/ocean-react/src/Alert/stories/Alert.stories.mdx
+++ b/packages/ocean-react/src/Alert/stories/Alert.stories.mdx
@@ -1,0 +1,125 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs';
+import { StarOutline } from '@useblu/ocean-icons-react';
+import Alert from '../Alert';
+
+<Meta title="Components/Alert" component={Alert} />
+
+# Alert API
+
+The API documentation of the alert React component. Learn more about the props and the CSS customization points.
+
+## Import
+
+```javascript
+import { Alert } from '@useblu/ocean-react';
+```
+
+## Usage
+
+<Canvas withSource="open" withToolbar>
+  <Story name="Usage">
+    <Alert>Hello There!</Alert>
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable of="." />
+
+The ref is forwarded to the root element.
+
+Any other props supplied will be provided to the root element (native element).
+
+### Simple alerts
+
+The alert offers four diferents default types that set a icon and color.
+
+<Canvas>
+  <Story name="default">
+    <Alert>This is an informational message.</Alert>
+  </Story>
+  <Story name="warning">
+    <Alert type="warning">This is an informational message.</Alert>
+  </Story>
+  <Story name="error">
+    <Alert type="error">This is an informational message.</Alert>
+  </Story>
+  <Story name="success">
+    <Alert type="success">This is an informational message.</Alert>
+  </Story>
+</Canvas>
+
+### Description
+
+You can use the `title` property to display a formatted title above the alert message.
+
+<Canvas>
+  <Story name="default-with-title">
+    <Alert title="Default Title">
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    </Alert>
+  </Story>
+  <Story name="warning-with-title">
+    <Alert type="warning" title="Warning Title">
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    </Alert>
+  </Story>
+  <Story name="error-with-title">
+    <Alert type="error" title="Error Title">
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    </Alert>
+  </Story>
+  <Story name="success-with-title">
+    <Alert type="success" title="Success Title!">
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    </Alert>
+  </Story>
+</Canvas>
+
+### Custom Icon
+
+You can also use the `icon` property to custom svg icon.
+
+<Canvas>
+  <Story name="default-with-custom-icon">
+    <Alert
+      title="Alert with a custom icon!"
+      icon={<StarOutline size={24} stroke="#5872f5" />}
+    >
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    </Alert>
+  </Story>
+</Canvas>
+
+## CSS
+
+| Global class           | Description                                               |
+| ---------------------- | --------------------------------------------------------- |
+| .ods-alert             | Styles applied to the root element.                       |
+| .ods-alert--has-header | Styles applied to the root element with a title proprity. |
+| .ods-alert--error      | Styles applied to the root element with a error type.     |
+| .ods-alert--warning    | Styles applied to the root element with a warning type.   |
+| .ods-alert--success    | Styles applied to the root element with a success type.   |
+| .ods-alert\_\_header   | Styles applied to the header element.                     |
+| .ods-alert\_\_icon     | Styles applied to the icon element.                       |
+| .ods-alert\_\_title    | Styles applied to the title element.                      |
+
+If that's not sufficient, you can check the [implementation of the component](https://github.com/ocean-ds/ocean-web/blob/master/packages/ocean-react/src/Alert/Alert.tsx) for more detail.
+
+## Playground
+
+<Canvas>
+  <Story
+    name="Playground"
+    args={{
+      title: 'My title',
+      type: 'default',
+      children: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    }}
+    argTypes={{
+      icon: { control: null },
+    }}
+  >
+    {(props) => <Alert {...props} />}
+  </Story>
+</Canvas>

--- a/packages/ocean-react/src/index.ts
+++ b/packages/ocean-react/src/index.ts
@@ -4,6 +4,9 @@ export * from './Typography';
 export { default as Grid } from './Grid';
 export * from './Grid';
 
+export { default as Alert } from './Alert';
+export * from './Alert';
+
 export { default as Button } from './Button';
 export * from './Button';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds a new Alert component, with all variations as shown in the [hand-off ](https://www.figma.com/file/PgLv9k22CHHZZ867HwN65y/%E2%9D%96-Ocean-DS-%2F-Core-Components?node-id=2856%3A23387) doc, plus a way to custom set an icon in the component. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/3322092/129431092-03f56331-6197-47a1-aa54-7af1c961f7bf.png)
![image](https://user-images.githubusercontent.com/3322092/129431097-697bd4fd-1c1f-4c14-8fbf-ec683419a35f.png)

## Checklist:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] My changes work in Chrome, Edge, and Firefox
- [x] I have made corresponding changes to the documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed
