### PR TITLE
fix(alert): adds a wrapper for content

### DIFF
--- a/packages/ocean-react/src/Alert/Alert.tsx
+++ b/packages/ocean-react/src/Alert/Alert.tsx
@@ -16,16 +16,14 @@ export type AlertProps = {
   /**
    * Sets a custon icon for the Alert.
    */
-  icon?: React.ReactNode;
+  icon?: React.ReactElement;
 } & React.ComponentPropsWithoutRef<'div'>;
 
 const Alert = React.forwardRef<HTMLDivElement, AlertProps>(function Alert(
   { children, type = 'default', title, className, icon, ...rest },
   ref
 ) {
-  const alertIcon = (
-    <AlertIcon type={type} icon={icon} className="ods-alert__icon" />
-  );
+  const alertIcon = <AlertIcon type={type} icon={icon} />;
 
   return (
     <div
@@ -47,8 +45,7 @@ const Alert = React.forwardRef<HTMLDivElement, AlertProps>(function Alert(
       ) : (
         alertIcon
       )}
-
-      {children}
+      <div className="ods-alert__content">{children}</div>
     </div>
   );
 });

--- a/packages/ocean-react/src/Alert/AlertIcon.tsx
+++ b/packages/ocean-react/src/Alert/AlertIcon.tsx
@@ -6,16 +6,10 @@ import {
   CheckCircleOutline,
 } from '@useblu/ocean-icons-react';
 
-export type AlertIconProps = {
-  /**
-   * Determines the type of alert, with default icon and colors for each type
-   */
+type AlertIconProps = {
   type: 'success' | 'warning' | 'error' | 'default';
-  /**
-   * Sets a title for the Alert
-   */
-  icon?: React.ReactNode;
-} & React.ComponentPropsWithoutRef<'div'>;
+  icon?: React.ReactElement;
+};
 
 const mapIconsByType = {
   warning: ExclamationCircleOutline,
@@ -30,7 +24,7 @@ const AlertIcon = React.memo<AlertIconProps>(function AlertIcon({
 }) {
   const IconEl = mapIconsByType[type];
 
-  if (icon) return <div className="ods-alert__icon">{icon}</div>;
+  if (icon) return React.cloneElement(icon, { className: 'ods-alert__icon' });
 
   return (
     <IconEl

--- a/packages/ocean-react/src/Alert/__tests__/Alert.test.tsx
+++ b/packages/ocean-react/src/Alert/__tests__/Alert.test.tsx
@@ -9,106 +9,162 @@ jest.mock('@useblu/ocean-icons-react', () => ({
   ExclamationCircleOutline: () => 'mock-exclamation-circle-outline',
   XCircleOutline: () => 'mock-x-circle-outline',
   CheckCircleOutline: () => 'mock-check-circle-outline',
-  StarOutline: () => 'mock-start-outline',
+  StarOutline: function StarOutlineMock(
+    props: React.HTMLAttributes<HTMLDivElement>
+  ) {
+    return <div {...props}>mock-start-circle-outline</div>;
+  },
 }));
 
 const setup = (props?: AlertProps) => {
-  render(<Alert {...props}>Hello There!</Alert>);
+  render(
+    <Alert {...props}>
+      <div className="ods-alert__content">Hello There!</div>
+    </Alert>
+  );
 };
 
 test('renders default element properly', () => {
   setup();
 
   expect(document.querySelector('.ods-alert')).toMatchInlineSnapshot(`
+<div
+  class="ods-alert ods-alert--default"
+  role="alert"
+>
+  mock-information-circle-outline
+  <div
+    class="ods-alert__content"
+  >
     <div
-      class="ods-alert ods-alert--default"
-      role="alert"
+      class="ods-alert__content"
     >
-      mock-information-circle-outline
       Hello There!
     </div>
-  `);
+  </div>
+</div>
+`);
 });
 
 test('renders success element properly', () => {
   setup({ type: 'success' });
 
   expect(document.querySelector('.ods-alert')).toMatchInlineSnapshot(`
+<div
+  class="ods-alert ods-alert--success"
+  role="alert"
+>
+  mock-check-circle-outline
+  <div
+    class="ods-alert__content"
+  >
     <div
-      class="ods-alert ods-alert--success"
-      role="alert"
+      class="ods-alert__content"
     >
-      mock-check-circle-outline
       Hello There!
     </div>
-  `);
+  </div>
+</div>
+`);
 });
 
 test('renders error element properly', () => {
   setup({ type: 'error' });
 
   expect(document.querySelector('.ods-alert')).toMatchInlineSnapshot(`
+<div
+  class="ods-alert ods-alert--error"
+  role="alert"
+>
+  mock-x-circle-outline
+  <div
+    class="ods-alert__content"
+  >
     <div
-      class="ods-alert ods-alert--error"
-      role="alert"
+      class="ods-alert__content"
     >
-      mock-x-circle-outline
       Hello There!
     </div>
-  `);
+  </div>
+</div>
+`);
 });
 
 test('renders element with a custom icon', () => {
   setup({ icon: <StarOutline /> });
 
   expect(document.querySelector('.ods-alert')).toMatchInlineSnapshot(`
+<div
+  class="ods-alert ods-alert--default"
+  role="alert"
+>
+  <div
+    class="ods-alert__icon"
+  >
+    mock-start-circle-outline
+  </div>
+  <div
+    class="ods-alert__content"
+  >
     <div
-      class="ods-alert ods-alert--default"
-      role="alert"
+      class="ods-alert__content"
     >
-      <div
-        class="ods-alert__icon"
-      >
-        mock-start-outline
-      </div>
       Hello There!
     </div>
-  `);
+  </div>
+</div>
+`);
 });
 
 test('renders warning element properly', () => {
   setup({ type: 'warning' });
 
   expect(document.querySelector('.ods-alert')).toMatchInlineSnapshot(`
+<div
+  class="ods-alert ods-alert--warning"
+  role="alert"
+>
+  mock-exclamation-circle-outline
+  <div
+    class="ods-alert__content"
+  >
     <div
-      class="ods-alert ods-alert--warning"
-      role="alert"
+      class="ods-alert__content"
     >
-      mock-exclamation-circle-outline
       Hello There!
     </div>
-  `);
+  </div>
+</div>
+`);
 });
 
 test('renders element properly with title', () => {
   setup({ title: "Test's Title" });
 
   expect(document.querySelector('.ods-alert')).toMatchInlineSnapshot(`
+<div
+  class="ods-alert ods-alert--default ods-alert--has-header"
+  role="alert"
+>
+  <div
+    class="ods-alert__header"
+  >
+    mock-information-circle-outline
     <div
-      class="ods-alert ods-alert--default ods-alert--has-header"
-      role="alert"
+      class="ods-alert__title"
     >
-      <div
-        class="ods-alert__header"
-      >
-        mock-information-circle-outline
-        <div
-          class="ods-alert__title"
-        >
-          Test's Title
-        </div>
-      </div>
+      Test's Title
+    </div>
+  </div>
+  <div
+    class="ods-alert__content"
+  >
+    <div
+      class="ods-alert__content"
+    >
       Hello There!
     </div>
-  `);
+  </div>
+</div>
+`);
 });

--- a/packages/ocean-react/src/Alert/stories/Alert.stories.mdx
+++ b/packages/ocean-react/src/Alert/stories/Alert.stories.mdx
@@ -17,8 +17,10 @@ import { Alert } from '@useblu/ocean-react';
 ## Usage
 
 <Canvas withSource="open" withToolbar>
-  <Story name="usage">
-    <Alert>Hello There!</Alert>
+  <Story name="Usage">
+    <Alert>
+      <strong>Atentention</strong>: Hello There!
+    </Alert>
   </Story>
 </Canvas>
 
@@ -103,6 +105,7 @@ You can also use the `icon` property to custom svg icon.
 | .ods-alert\_\_header   | Styles applied to the header element.                     |
 | .ods-alert\_\_icon     | Styles applied to the icon element.                       |
 | .ods-alert\_\_title    | Styles applied to the title element.                      |
+| .ods-alert\_\_content  | Styles applied to the content element.                    |
 
 If that's not sufficient, you can check the [implementation of the component](https://github.com/ocean-ds/ocean-web/blob/master/packages/ocean-react/src/Alert/Alert.tsx) for more detail.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a wrapper to the alert content, to let user to have a alert with how many children they want. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots (if appropriate):

without the fix
![image](https://user-images.githubusercontent.com/3322092/129717260-2f12df69-685d-471a-9a1a-c22b3baf8321.png)

with the fix
![image](https://user-images.githubusercontent.com/3322092/129717310-12574bfa-3414-40f4-9f78-449941c4a6ed.png)

## Checklist:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] My changes work in Chrome, Edge, and Firefox
- [x] I have made corresponding changes to the documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed
