### PR TITLE
fix: double select z-index problem

### DIFF
--- a/packages/ocean-core/src/forms/_select.scss
+++ b/packages/ocean-core/src/forms/_select.scss
@@ -84,6 +84,7 @@
 
   &__listbox-wrapper {
     position: relative;
+    z-index: 2;
   }
 
   &__listbox {


### PR DESCRIPTION
## Description

Adding a z-index css property to the select stylesheet page to fix the double select issue.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots:

### Before
<img width="817" alt="Screen Shot 2021-11-01 at 15 55 56" src="https://user-images.githubusercontent.com/55864118/139730457-e84949c6-c85e-446c-a3e5-b89bc6b7f7ff.png">

### After
<img width="817" alt="Screen Shot 2021-11-01 at 15 56 17" src="https://user-images.githubusercontent.com/55864118/139730492-f7d6c886-425a-4566-8173-4775bd3d1329.png">
 
## Checklist:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] My changes work in Chrome, Edge, and Firefox
- [x] I have made corresponding changes to the documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed
