### PR TITLE
fix(badge): fixes badge not being displayed properly on count=0

### DIFF
--- a/packages/ocean-react/src/Badge/Badge.tsx
+++ b/packages/ocean-react/src/Badge/Badge.tsx
@@ -38,7 +38,7 @@ const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(function Badge(
       )}
       {...rest}
     >
-      {variation !== 'tiny' && count && (
+      {variation !== 'tiny' && typeof count !== 'undefined' && (
         <div className="ods-badge__content ods-badge__count">{countToShow}</div>
       )}
 

--- a/packages/ocean-react/src/Badge/__tests__/Badge.test.tsx
+++ b/packages/ocean-react/src/Badge/__tests__/Badge.test.tsx
@@ -69,6 +69,28 @@ test('renders element with count more then 99', () => {
 `);
 });
 
+test('renders element with count equals 0', () => {
+  render(
+    <Badge count={0} data-testid="btn-test" className="custom-class">
+      Hello
+    </Badge>
+  );
+
+  expect(screen.getByTestId('btn-test')).toMatchInlineSnapshot(`
+<div
+  class="ods-badge ods-badge--small ods-badge--undefined custom-class"
+  data-testid="btn-test"
+  role="tag"
+>
+  <div
+    class="ods-badge__content ods-badge__count"
+  >
+    0
+  </div>
+</div>
+`);
+});
+
 test('renders element with variation', () => {
   render(
     <Badge variation="tiny" data-testid="btn-test" className="custom-class">

--- a/packages/ocean-react/src/Badge/stories/Badge.stories.mdx
+++ b/packages/ocean-react/src/Badge/stories/Badge.stories.mdx
@@ -18,6 +18,8 @@ import { Badge } from '@useblu/ocean-react';
 
 <Canvas withSource="open" withToolbar>
   <Story name="count">
+    <Badge count={0} />
+    <br />
     <Badge count={1} />
     <br />
     <Badge count={99} />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes the badge component when count prop is zero.
Due to 0 being interpreted as a falsy value it made the condition where the badge styles were applied simply got ignored.
Since `count` can only be `number | undefined` I chose to strictly check if its not `undefined`.

Also added a test specifically checking if the badge with `count={0}` matches the snapshot of a expected dom node.

Fixes # (issue)
[CB-1350](https://useblu.atlassian.net/jira/software/c/projects/CB/boards/106?modal=detail&selectedIssue=CB-1350)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

https://ocean-ds.github.io/ocean-web/?path=/story/components-badge--count

or locally:

http://localhost:6006/?path=/story/components-badge--count

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/105744648/181103517-f7a6038c-c471-4a67-ab58-903c085c153e.png)

## Checklist:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] My changes work in Chrome, Edge, and Firefox
- [x] I have made corresponding changes to the documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed
