### PR TITLE
feat(crosssellcard): CustomIcon + increases the clickable area for the whole component 

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,14 +9,14 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [master]
   schedule:
     - cron: '22 13 * * 6'
 
@@ -32,39 +32,39 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
+        language: ['javascript']
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+      #- run: |
+      #   make bootstrap
+      #   make release
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -1,4 +1,4 @@
-name: "Lint PR"
+name: 'Lint PR'
 
 on:
   pull_request_target:

--- a/packages/ocean-core/src/components/_cross-sell-card.scss
+++ b/packages/ocean-core/src/components/_cross-sell-card.scss
@@ -75,10 +75,8 @@
       outline: $color-brand-primary-pure auto $border-width-hairline;
     }
 
-    &-icon {
-      svg {
-        color: $color-brand-primary-pure;
-      }
+    &-icon svg {
+      color: $color-brand-primary-pure;
     }
   }
 }

--- a/packages/ocean-core/src/components/_cross-sell-card.scss
+++ b/packages/ocean-core/src/components/_cross-sell-card.scss
@@ -1,8 +1,8 @@
 .ods-cross-sell-card {
   border-radius: $border-radius-md;
+  cursor: pointer;
   min-height: 156px;
   width: 100%;
-  cursor: pointer;
 
   &__content {
     align-items: center;

--- a/packages/ocean-core/src/components/_cross-sell-card.scss
+++ b/packages/ocean-core/src/components/_cross-sell-card.scss
@@ -2,6 +2,7 @@
   border-radius: $border-radius-md;
   min-height: 156px;
   width: 100%;
+  cursor: pointer;
 
   &__content {
     align-items: center;

--- a/packages/ocean-core/src/components/_cross-sell-card.scss
+++ b/packages/ocean-core/src/components/_cross-sell-card.scss
@@ -4,16 +4,6 @@
   min-height: 156px;
   width: 100%;
 
-  &:hover {
-    .ods-cross-sell-card__content {
-      background-color: $color-brand-primary-deep;
-    }
-
-    .ods-cross-sell-card__cta {
-      background: $color-interface-light-up;
-    }
-  }
-
   &__content {
     align-items: center;
     background-color: $color-brand-primary-pure;

--- a/packages/ocean-core/src/components/_cross-sell-card.scss
+++ b/packages/ocean-core/src/components/_cross-sell-card.scss
@@ -76,7 +76,9 @@
     }
 
     &-icon {
-      color: $color-brand-primary-pure;
+      svg {
+        color: $color-brand-primary-pure;
+      }
     }
   }
 }

--- a/packages/ocean-core/src/components/_cross-sell-card.scss
+++ b/packages/ocean-core/src/components/_cross-sell-card.scss
@@ -4,6 +4,16 @@
   min-height: 156px;
   width: 100%;
 
+  &:hover {
+    .ods-cross-sell-card__content {
+      background-color: $color-brand-primary-deep;
+    }
+
+    .ods-cross-sell-card__cta {
+      background: $color-interface-light-up;
+    }
+  }
+
   &__content {
     align-items: center;
     background-color: $color-brand-primary-pure;
@@ -14,6 +24,7 @@
     gap: $spacing-inline-xs;
     justify-content: center;
     padding: $spacing-squish-md;
+    transition: background 0.1s ease-in;
 
     @include media-breakpoint-down(lg) {
       padding: $spacing-inset-sm;

--- a/packages/ocean-react/src/CrossSellCard/CrossSellCard.tsx
+++ b/packages/ocean-react/src/CrossSellCard/CrossSellCard.tsx
@@ -35,8 +35,9 @@ const CrossSellCard = React.forwardRef<HTMLDivElement, CrossSellCardProps>(
         ref={ref}
         {...rest}
         className={classNames('ods-cross-sell-card', className)}
+        onClick={ctaAction}
       >
-        <div className="ods-cross-sell-card__content">
+        <div className="ods-cross-sell-card__content" onClick={() => ctaAction}>
           <div className="ods-cross-sell-card__information">
             <div className="ods-typography--inverse ods-typography__heading3">
               {title}
@@ -52,7 +53,7 @@ const CrossSellCard = React.forwardRef<HTMLDivElement, CrossSellCardProps>(
 
         <button
           className="ods-cross-sell-card__cta"
-          onClick={ctaAction}
+          onClick={() => ctaAction}
           data-testid="cta-test"
         >
           {ctaText} <ChevronRight className="ods-cross-sell-card__cta-icon" />

--- a/packages/ocean-react/src/CrossSellCard/CrossSellCard.tsx
+++ b/packages/ocean-react/src/CrossSellCard/CrossSellCard.tsx
@@ -37,7 +37,11 @@ const CrossSellCard = React.forwardRef<HTMLDivElement, CrossSellCardProps>(
         className={classNames('ods-cross-sell-card', className)}
         onClick={ctaAction}
       >
-        <div className="ods-cross-sell-card__content" onClick={() => ctaAction}>
+        <div
+          className="ods-cross-sell-card__content"
+          onClick={() => ctaAction}
+          data-testid="cta-test"
+        >
           <div className="ods-cross-sell-card__information">
             <div className="ods-typography--inverse ods-typography__heading3">
               {title}
@@ -51,11 +55,7 @@ const CrossSellCard = React.forwardRef<HTMLDivElement, CrossSellCardProps>(
           )}
         </div>
 
-        <button
-          className="ods-cross-sell-card__cta"
-          onClick={() => ctaAction}
-          data-testid="cta-test"
-        >
+        <button className="ods-cross-sell-card__cta">
           {ctaText} <ChevronRight className="ods-cross-sell-card__cta-icon" />
         </button>
       </div>

--- a/packages/ocean-react/src/CrossSellCard/CrossSellCard.tsx
+++ b/packages/ocean-react/src/CrossSellCard/CrossSellCard.tsx
@@ -20,6 +20,10 @@ export type CrossSellCardProps = {
    */
   ctaText: string;
   /**
+   * Determines the Icon on the
+   */
+  customIcon?: JSX.Element;
+  /**
    * Determines the cta action
    */
   ctaAction: () => void;
@@ -27,7 +31,16 @@ export type CrossSellCardProps = {
 
 const CrossSellCard = React.forwardRef<HTMLDivElement, CrossSellCardProps>(
   function CrossSellCard(
-    { title, className, description, imageSrc, ctaText, ctaAction, ...rest },
+    {
+      title,
+      className,
+      description,
+      imageSrc,
+      ctaText,
+      ctaAction,
+      customIcon,
+      ...rest
+    },
     ref
   ) {
     return (
@@ -37,7 +50,7 @@ const CrossSellCard = React.forwardRef<HTMLDivElement, CrossSellCardProps>(
         className={classNames('ods-cross-sell-card', className)}
         onClick={ctaAction}
       >
-        <div
+        <a
           className="ods-cross-sell-card__content"
           onClick={() => ctaAction}
           data-testid="cta-test"
@@ -53,10 +66,13 @@ const CrossSellCard = React.forwardRef<HTMLDivElement, CrossSellCardProps>(
           {imageSrc && (
             <img className="ods-cross-sell-card__image" src={imageSrc} />
           )}
-        </div>
+        </a>
 
         <button className="ods-cross-sell-card__cta">
-          {ctaText} <ChevronRight className="ods-cross-sell-card__cta-icon" />
+          {ctaText}{' '}
+          <span className="ods-cross-sell-card__cta-icon">
+            {customIcon || <ChevronRight />}
+          </span>
         </button>
       </div>
     );

--- a/packages/ocean-react/src/CrossSellCard/__tests__/CrossSellCard.tsx
+++ b/packages/ocean-react/src/CrossSellCard/__tests__/CrossSellCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import CrossSellCard from '../CrossSellCard';
+import { ChevronLeft } from '@useblu/ocean-icons-react';
 
 const mockFunction = jest.fn();
 
@@ -22,7 +23,7 @@ test('renders element properly', () => {
       class="ods-cross-sell-card custom-class"
       data-testid="csc-test"
     >
-      <div
+      <a
         class="ods-cross-sell-card__content"
         data-testid="cta-test"
       >
@@ -44,26 +45,29 @@ test('renders element properly', () => {
           class="ods-cross-sell-card__image"
           src="../img/placeholder.svg"
         />
-      </div>
+      </a>
       <button
         class="ods-cross-sell-card__cta"
       >
         Cta Text Test
          
-        <svg
+        <span
           class="ods-cross-sell-card__cta-icon"
-          fill="currentColor"
-          height="24"
-          viewBox="0 0 20 20"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
         >
-          <path
-            clip-rule="evenodd"
-            d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-            fill-rule="evenodd"
-          />
-        </svg>
+          <svg
+            fill="currentColor"
+            height="24"
+            viewBox="0 0 20 20"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </span>
       </button>
     </div>
   `);
@@ -82,4 +86,73 @@ test('action is being fired', () => {
   );
   fireEvent.click(screen.getByTestId('cta-test'));
   expect(mockFunction).toHaveBeenCalledTimes(1);
+});
+
+test('renders component with custom icon', () => {
+  render(
+    <CrossSellCard
+      title="Card Title"
+      description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+      imageSrc={'../img/placeholder.svg'}
+      ctaText="Call To Action"
+      ctaAction={mockFunction}
+      className="custom-class"
+      data-testid="csc-test"
+      customIcon={<ChevronLeft />}
+    />
+  );
+
+  expect(screen.getByTestId('csc-test')).toMatchInlineSnapshot(`
+    <div
+      class="ods-cross-sell-card custom-class"
+      data-testid="csc-test"
+    >
+      <a
+        class="ods-cross-sell-card__content"
+        data-testid="cta-test"
+      >
+        <div
+          class="ods-cross-sell-card__information"
+        >
+          <div
+            class="ods-typography--inverse ods-typography__heading3"
+          >
+            Card Title
+          </div>
+          <div
+            class="ods-typography--inverse ods-typography__description ods-cross-sell-card__description "
+          >
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          </div>
+        </div>
+        <img
+          class="ods-cross-sell-card__image"
+          src="../img/placeholder.svg"
+        />
+      </a>
+      <button
+        class="ods-cross-sell-card__cta"
+      >
+        Call To Action
+         
+        <span
+          class="ods-cross-sell-card__cta-icon"
+        >
+          <svg
+            fill="currentColor"
+            height="24"
+            viewBox="0 0 20 20"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+  `);
 });

--- a/packages/ocean-react/src/CrossSellCard/__tests__/CrossSellCard.tsx
+++ b/packages/ocean-react/src/CrossSellCard/__tests__/CrossSellCard.tsx
@@ -24,6 +24,7 @@ test('renders element properly', () => {
     >
       <div
         class="ods-cross-sell-card__content"
+        data-testid="cta-test"
       >
         <div
           class="ods-cross-sell-card__information"
@@ -46,7 +47,6 @@ test('renders element properly', () => {
       </div>
       <button
         class="ods-cross-sell-card__cta"
-        data-testid="cta-test"
       >
         Cta Text Test
          

--- a/packages/ocean-react/src/FormLabel/FormLabel.tsx
+++ b/packages/ocean-react/src/FormLabel/FormLabel.tsx
@@ -39,8 +39,8 @@ function FormLabelBase<T extends React.ElementType = 'label'>(
   );
 }
 
-const FormLabel = (React.forwardRef(
+const FormLabel = React.forwardRef(
   FormLabelBase
-) as unknown) as typeof FormLabelBase;
+) as unknown as typeof FormLabelBase;
 
 export default FormLabel;

--- a/packages/ocean-react/src/FormLabel/__tests__/FormLabel.test.tsx
+++ b/packages/ocean-react/src/FormLabel/__tests__/FormLabel.test.tsx
@@ -22,9 +22,10 @@ test('renders element properly', () => {
 
 test('renders a disabled state', () => {
   render(<FormLabel data-testid="lbl-test" disabled />);
-  expect(
-    screen.getByTestId('lbl-test')
-  ).toHaveClass('ods-form-label ods-form-label--disabled', { exact: true });
+  expect(screen.getByTestId('lbl-test')).toHaveClass(
+    'ods-form-label ods-form-label--disabled',
+    { exact: true }
+  );
 });
 
 test('renders a span element', () => {

--- a/packages/ocean-react/src/Grid/__tests__/Col.test.tsx
+++ b/packages/ocean-react/src/Grid/__tests__/Col.test.tsx
@@ -38,9 +38,10 @@ test('includes "ods-col" when span of xs is true', () => {
 test('includes sizes', () => {
   render(<Col data-testid="grid-col" xs="4" md="8" lg={{ span: '12' }} />);
 
-  expect(
-    screen.getByTestId('grid-col')
-  ).toHaveClass('ods-col-4 ods-col-md-8 ods-col-lg-12', { exact: true });
+  expect(screen.getByTestId('grid-col')).toHaveClass(
+    'ods-col-4 ods-col-md-8 ods-col-lg-12',
+    { exact: true }
+  );
 });
 
 test('includes offsets', () => {
@@ -53,9 +54,7 @@ test('includes offsets', () => {
     />
   );
 
-  expect(
-    screen.getByTestId('grid-col')
-  ).toHaveClass(
+  expect(screen.getByTestId('grid-col')).toHaveClass(
     'ods-col-4 ods-offset-1 ods-col-md-8 ods-col-lg ods-offset-lg-2',
     { exact: true }
   );
@@ -72,7 +71,8 @@ test('allows span to be false', () => {
 test('allows span to be auto', () => {
   render(<Col data-testid="grid-col" md="auto" lg={{ span: 'auto' }} />);
 
-  expect(
-    screen.getByTestId('grid-col')
-  ).toHaveClass('ods-col-md-auto ods-col-lg-auto', { exact: true });
+  expect(screen.getByTestId('grid-col')).toHaveClass(
+    'ods-col-md-auto ods-col-lg-auto',
+    { exact: true }
+  );
 });

--- a/packages/ocean-react/src/Grid/__tests__/Row.test.tsx
+++ b/packages/ocean-react/src/Grid/__tests__/Row.test.tsx
@@ -29,7 +29,8 @@ test('render no-gutters correctly', () => {
 
 test('include number sizes', () => {
   render(<Row data-testid="grid-row" xs="4" md="6" />);
-  expect(
-    screen.getByTestId('grid-row')
-  ).toHaveClass('ods-row ods-row-cols-4 ods-row-cols-md-6', { exact: true });
+  expect(screen.getByTestId('grid-row')).toHaveClass(
+    'ods-row ods-row-cols-4 ods-row-cols-md-6',
+    { exact: true }
+  );
 });

--- a/packages/ocean-react/src/IconButton/IconButton.tsx
+++ b/packages/ocean-react/src/IconButton/IconButton.tsx
@@ -52,8 +52,8 @@ function IconButtonBase<T extends React.ElementType = 'button'>(
   );
 }
 
-const IconButton = (React.forwardRef(
+const IconButton = React.forwardRef(
   IconButtonBase
-) as unknown) as typeof IconButtonBase;
+) as unknown as typeof IconButtonBase;
 
 export default IconButton;

--- a/packages/ocean-react/src/Select/Option.tsx
+++ b/packages/ocean-react/src/Select/Option.tsx
@@ -13,13 +13,12 @@ import { OptionProps } from './types';
 
 const Option = React.memo<OptionProps>(function Option(option) {
   const { label, className, id, index, ...rest } = option;
-  const { selected, onSelect, setIsExpanded, refSelControl } = useContext(
-    Context
+  const { selected, onSelect, setIsExpanded, refSelControl } =
+    useContext(Context);
+  const isSelected = useMemo(
+    () => selected?.index === index,
+    [selected, index]
   );
-  const isSelected = useMemo(() => selected?.index === index, [
-    selected,
-    index,
-  ]);
   const refOption = useRef<HTMLLIElement | null>(null);
 
   useEffect(() => {


### PR DESCRIPTION
makes the whole component clickable, executing the ctaAction function passed as prop

## Description
Adds a custom icon prop to the component, a JSX.Element can be passed and it will appear near the bottom right where the button icon is. Falls back to the ChevronRight icon which was already used by default.

CrossSellCard component needed an increased clickable area. Added a onClick on the div and fixed an issue that prevent the ctaAction from being fired twice.

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

https://ocean-ds.github.io/ocean-web/?path=/story/components-crosssellcard--usage

or locally:

http://localhost:6006/?path=/story/components-crosssellcard--usage

## Screenshots (if appropriate):

## Checklist:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] My changes work in Chrome, Edge, and Firefox
- [x] I have made corresponding changes to the documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed
