### PR TITLE
fix: adjust sub header padding and height

### DIFF
--- a/packages/ocean-core/src/components/_sub-header.scss
+++ b/packages/ocean-core/src/components/_sub-header.scss
@@ -1,9 +1,9 @@
 .ods-sub-header {
+  align-items: center;
   background-color: $color-interface-light-up;
   box-sizing: border-box;
   display: flex;
   justify-content: space-between;
-  align-items: center;
   min-height: 40px;
   padding: $spacing-stack-xxs $spacing-stack-xs;
   width: 100%;

--- a/packages/ocean-core/src/components/_sub-header.scss
+++ b/packages/ocean-core/src/components/_sub-header.scss
@@ -3,7 +3,9 @@
   box-sizing: border-box;
   display: flex;
   justify-content: space-between;
-  padding: 12px $spacing-stack-xs $spacing-stack-xxs $spacing-stack-xs;
+  align-items: center;
+  min-height: 40px;
+  padding: $spacing-stack-xxs $spacing-stack-xs;
   width: 100%;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adjust sub header padding and min height, according this issue https://github.com/ocean-ds/ocean-web/issues/1049

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] My changes work in Chrome, Edge, and Firefox
- [x] I have made corresponding changes to the documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed
