### PR TITLE
fix: adds a 8px margin to the input component label

### DIFF
--- a/packages/ocean-core/src/forms/_form-control.scss
+++ b/packages/ocean-core/src/forms/_form-control.scss
@@ -11,6 +11,7 @@
     display: flex;
     flex-direction: row;
     text-align: center;
+    margin-bottom: $spacing-inline-xxs;
   }
 
   &__label {

--- a/packages/ocean-core/src/forms/_form-control.scss
+++ b/packages/ocean-core/src/forms/_form-control.scss
@@ -10,8 +10,8 @@
     align-items: center;
     display: flex;
     flex-direction: row;
-    text-align: center;
     margin-bottom: $spacing-inline-xxs;
+    text-align: center;
   }
 
   &__label {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes the input label margin-bottom 

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots (if appropriate):
![Screenshot 2022-12-21 at 18 02 28](https://user-images.githubusercontent.com/55864118/209002172-535d580d-2070-4482-adfb-f4c32f0235f7.png)

![Screenshot 2022-12-21 at 18 02 38](https://user-images.githubusercontent.com/55864118/209002202-605a211c-e1b5-4034-b3f4-918537a0500a.png)

## Checklist:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] My changes work in Chrome, Edge, and Firefox
- [x] I have made corresponding changes to the documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed
