### PR TITLE
feat: add attach mode to drawer

### DIFF
--- a/packages/ocean-core/src/components/_drawer.scss
+++ b/packages/ocean-core/src/components/_drawer.scss
@@ -23,15 +23,24 @@
   flex-shrink: 0;
 
   height: 100%;
-  left: auto;
   outline: 0;
   position: fixed;
-  right: 0;
   top: 0;
-  transform: translateX(100%);
   transition: all 335ms ease-out 0ms;
   visibility: hidden;
   width: 378px;
+
+  &--right {
+    left: auto;
+    right: 0;
+    transform: translateX(100%);
+  }
+
+  &--left {
+    left: 0;
+    right: auto;
+    transform: translateX(-100%);
+  }
 
   &--open {
     box-shadow: 0 8px 10px -5px rgba(0, 0, 0, 0.2),

--- a/packages/ocean-core/src/components/_drawer.scss
+++ b/packages/ocean-core/src/components/_drawer.scss
@@ -2,6 +2,7 @@
   background-color: rgba(0, 0, 0, 0.5);
   height: 100%;
   opacity: 0;
+  overflow: hidden;
   position: fixed;
   right: 0;
   top: 0;
@@ -24,7 +25,7 @@
 
   height: 100%;
   outline: 0;
-  position: fixed;
+  position: absolute;
   top: 0;
   transition: all 335ms ease-out 0ms;
   visibility: hidden;

--- a/packages/ocean-react/src/Drawer/Drawer.tsx
+++ b/packages/ocean-react/src/Drawer/Drawer.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import React from 'react';
 
 import classNames from 'classnames';
@@ -10,7 +11,8 @@ interface DrawerProps {
   onDrawerClose?(event: React.MouseEvent | React.KeyboardEvent): void;
   overlayClose: () => void;
   headerIcon?: React.ReactNode;
-  iconAlignment?: string;
+  align?: 'right' | 'left';
+  iconAlignment?: 'right' | 'left';
 }
 
 const Drawer = ({
@@ -18,6 +20,7 @@ const Drawer = ({
   open,
   onDrawerClose,
   overlayClose,
+  align = 'right',
   headerIcon = <XOutline />,
   iconAlignment = 'right',
 }: DrawerProps): React.ReactElement => (
@@ -27,7 +30,13 @@ const Drawer = ({
       aria-hidden="true"
       onClick={overlayClose}
     />
-    <div className={classNames('ods-drawer', open && 'ods-drawer--open')}>
+    <div
+      className={classNames(
+        'ods-drawer',
+        open && 'ods-drawer--open',
+        `ods-drawer--${align}`
+      )}
+    >
       <div
         className={classNames(
           'ods-drawer__content--header',

--- a/packages/ocean-react/src/Drawer/Drawer.tsx
+++ b/packages/ocean-react/src/Drawer/Drawer.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-import React from 'react';
+import React, { RefObject, useCallback, useEffect, useRef } from 'react';
 
 import classNames from 'classnames';
 import { XOutline } from '@useblu/ocean-icons-react';
@@ -13,6 +12,7 @@ interface DrawerProps {
   headerIcon?: React.ReactNode;
   align?: 'right' | 'left';
   iconAlignment?: 'right' | 'left';
+  anchorEl?: RefObject<HTMLDivElement> | null;
 }
 
 const Drawer = ({
@@ -23,33 +23,72 @@ const Drawer = ({
   align = 'right',
   headerIcon = <XOutline />,
   iconAlignment = 'right',
-}: DrawerProps): React.ReactElement => (
-  <>
+  anchorEl,
+}: DrawerProps): React.ReactElement => {
+  const drawerRef = useRef<HTMLDivElement>(null);
+
+  const getAnchorPosition = useCallback(() => {
+    if (!anchorEl?.current) return null;
+
+    const position = anchorEl.current.getBoundingClientRect();
+
+    if (align === 'right') {
+      return {
+        width: `${position.right}px`,
+        right: `${position.right}px`,
+        left: 'auto',
+      };
+    }
+
+    return {
+      width: `${position.right}px`,
+      right: 'auto',
+      left: `${position.right}px`,
+    };
+  }, [align, anchorEl]);
+
+  const attachDrawer = useCallback(() => {
+    const position = getAnchorPosition();
+
+    if (!drawerRef.current || !position) return;
+
+    drawerRef.current.style.width = `calc(100% - ${position?.width}px)})`;
+    drawerRef.current.style.left = position.left;
+    drawerRef.current.style.right = position.right;
+  }, [getAnchorPosition]);
+
+  useEffect(() => {
+    attachDrawer();
+  }, [anchorEl, drawerRef, attachDrawer]);
+
+  return (
     <div
       className={classNames('ods-overlay', open && 'ods-overlay--open')}
       aria-hidden="true"
       onClick={overlayClose}
-    />
-    <div
-      className={classNames(
-        'ods-drawer',
-        open && 'ods-drawer--open',
-        `ods-drawer--${align}`
-      )}
+      ref={drawerRef}
     >
       <div
         className={classNames(
-          'ods-drawer__content--header',
-          `ods-drawer__content--header--${iconAlignment}`
+          'ods-drawer',
+          open && 'ods-drawer--open',
+          `ods-drawer--${align}`
         )}
       >
-        <Button type="button" onClick={onDrawerClose}>
-          {headerIcon}
-        </Button>
+        <div
+          className={classNames(
+            'ods-drawer__content--header',
+            `ods-drawer__content--header--${iconAlignment}`
+          )}
+        >
+          <Button type="button" onClick={onDrawerClose}>
+            {headerIcon}
+          </Button>
+        </div>
+        {children}
       </div>
-      {children}
     </div>
-  </>
-);
+  );
+};
 
 export default Drawer;

--- a/packages/ocean-react/src/Drawer/Drawer.tsx
+++ b/packages/ocean-react/src/Drawer/Drawer.tsx
@@ -33,9 +33,11 @@ const Drawer = ({
     const position = anchorEl.current.getBoundingClientRect();
 
     if (align === 'right') {
+      const size = window.innerWidth - position.left;
+
       return {
-        width: `${position.right}px`,
-        right: `${position.right}px`,
+        width: `${size}px`,
+        right: `${size}px`,
         left: 'auto',
       };
     }

--- a/packages/ocean-react/src/Drawer/__tests__/Drawer.test.tsx
+++ b/packages/ocean-react/src/Drawer/__tests__/Drawer.test.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import SimpleDrawer from '../../Drawer/examples/SimpleDrawer';
+import AttachedDrawer from '../../Drawer/examples/AttachedDrawer';
 
 jest.mock('@useblu/ocean-icons-react', () => ({
   XOutline: () => 'mock-x-outline-xvg',
 }));
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const setup = (props: any) => {
   render(
     <SimpleDrawer {...props}>
@@ -41,6 +43,66 @@ test('renders drawer component properly', () => {
   `);
 });
 
+test('renders drawer attached to div on right', () => {
+  render(
+    <AttachedDrawer>
+      <p>Drawer content!</p>
+    </AttachedDrawer>
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: 'Open drawer' }));
+
+  expect(document.querySelector('.ods-drawer')).toMatchInlineSnapshot(`
+    <div
+      class="ods-drawer ods-drawer--open ods-drawer--right"
+    >
+      <div
+        class="ods-drawer__content--header ods-drawer__content--header--right"
+      >
+        <button
+          class="ods-btn ods-btn--md ods-btn--primary"
+          type="button"
+        >
+          mock-x-outline-xvg
+        </button>
+      </div>
+      <p>
+        Drawer content!
+      </p>
+    </div>
+  `);
+});
+
+test('renders drawer attached to div on left', () => {
+  render(
+    <AttachedDrawer align="left">
+      <p>Drawer content!</p>
+    </AttachedDrawer>
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: 'Open drawer' }));
+
+  expect(document.querySelector('.ods-drawer')).toMatchInlineSnapshot(`
+    <div
+      class="ods-drawer ods-drawer--open ods-drawer--left"
+    >
+      <div
+        class="ods-drawer__content--header ods-drawer__content--header--right"
+      >
+        <button
+          class="ods-btn ods-btn--md ods-btn--primary"
+          type="button"
+        >
+          mock-x-outline-xvg
+        </button>
+      </div>
+      <p>
+        Drawer content!
+      </p>
+    </div>
+  `);
+});
+
 test('close the drawer', () => {
   setup({ open: false });
 
@@ -57,5 +119,14 @@ test.each(['right', 'left'] as const)(
     expect(
       document.querySelector(`.ods-drawer__content--header--${iconAlignment}`)
     ).toBeInTheDocument();
+  }
+);
+
+test.each(['right', 'left'] as const)(
+  'renders ods-drawer in each side',
+  (align) => {
+    setup({ align });
+
+    expect(document.querySelector(`.ods-drawer--${align}`)).toBeInTheDocument();
   }
 );

--- a/packages/ocean-react/src/Drawer/__tests__/Drawer.test.tsx
+++ b/packages/ocean-react/src/Drawer/__tests__/Drawer.test.tsx
@@ -22,7 +22,7 @@ test('renders drawer component properly', () => {
 
   expect(document.querySelector('.ods-drawer')).toMatchInlineSnapshot(`
     <div
-      class="ods-drawer ods-drawer--open"
+      class="ods-drawer ods-drawer--open ods-drawer--right"
     >
       <div
         class="ods-drawer__content--header ods-drawer__content--header--right"

--- a/packages/ocean-react/src/Drawer/examples/AttachedDrawer.tsx
+++ b/packages/ocean-react/src/Drawer/examples/AttachedDrawer.tsx
@@ -1,0 +1,73 @@
+import React, { useRef, useState } from 'react';
+
+import Drawer from '../Drawer';
+import Button from '../../Button';
+
+export interface SimpleDrawerProps {
+  children: React.ReactElement;
+  open?: boolean;
+  align?: 'left' | 'right';
+  iconAlignment?: 'left' | 'right';
+}
+
+const SimpleDrawer = ({
+  children,
+  open,
+  align,
+  iconAlignment,
+}: SimpleDrawerProps): React.ReactElement => {
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleOpen = () => setIsOpen((prevState) => !prevState);
+
+  const toggleOverlayClose = () => setIsOpen(false);
+
+  return (
+    <>
+      <div
+        ref={anchorRef}
+        style={{
+          position: 'absolute',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          padding: '0 24px',
+          top: '0',
+          left: align === 'left' ? '0' : 'auto',
+          right: align === 'right' ? '0' : 'auto',
+          height: '100%',
+          backgroundColor: '#0025e0',
+        }}
+      >
+        <h3
+          style={{
+            fontFamily: 'Avenir',
+            fontSize: '20px',
+            fontWeight: '800',
+            lineHeight: '22px',
+            color: '#FFFFFF',
+            margin: '0 0 8px 0',
+          }}
+        >
+          Anchor element
+        </h3>
+      </div>
+      <Button onClick={toggleOpen} type="button">
+        Open drawer
+      </Button>
+      <Drawer
+        open={open || isOpen}
+        onDrawerClose={toggleOpen}
+        overlayClose={toggleOverlayClose}
+        iconAlignment={iconAlignment}
+        align={align}
+        anchorEl={anchorRef}
+      >
+        {children}
+      </Drawer>
+    </>
+  );
+};
+
+export default SimpleDrawer;

--- a/packages/ocean-react/src/Drawer/examples/AttachedDrawer.tsx
+++ b/packages/ocean-react/src/Drawer/examples/AttachedDrawer.tsx
@@ -57,7 +57,7 @@ const SimpleDrawer = ({
         Open drawer
       </Button>
       <Drawer
-        open={open || isOpen}
+        open={open ?? isOpen}
         onDrawerClose={toggleOpen}
         overlayClose={toggleOverlayClose}
         iconAlignment={iconAlignment}

--- a/packages/ocean-react/src/Drawer/examples/AttachedDrawer.tsx
+++ b/packages/ocean-react/src/Drawer/examples/AttachedDrawer.tsx
@@ -57,7 +57,7 @@ const SimpleDrawer = ({
         Open drawer
       </Button>
       <Drawer
-        open={open ?? isOpen}
+        open={open || isOpen}
         onDrawerClose={toggleOpen}
         overlayClose={toggleOverlayClose}
         iconAlignment={iconAlignment}

--- a/packages/ocean-react/src/Drawer/examples/SimpleDrawer.tsx
+++ b/packages/ocean-react/src/Drawer/examples/SimpleDrawer.tsx
@@ -28,7 +28,7 @@ const SimpleDrawer = ({
         Open drawer
       </Button>
       <Drawer
-        open={open ?? isOpen}
+        open={open || isOpen}
         onDrawerClose={toggleOpen}
         overlayClose={toggleOverlayClose}
         iconAlignment={iconAlignment}

--- a/packages/ocean-react/src/Drawer/examples/SimpleDrawer.tsx
+++ b/packages/ocean-react/src/Drawer/examples/SimpleDrawer.tsx
@@ -28,7 +28,7 @@ const SimpleDrawer = ({
         Open drawer
       </Button>
       <Drawer
-        open={open || isOpen}
+        open={open ?? isOpen}
         onDrawerClose={toggleOpen}
         overlayClose={toggleOverlayClose}
         iconAlignment={iconAlignment}

--- a/packages/ocean-react/src/Drawer/examples/SimpleDrawer.tsx
+++ b/packages/ocean-react/src/Drawer/examples/SimpleDrawer.tsx
@@ -6,12 +6,14 @@ import Button from '../../Button';
 export interface SimpleDrawerProps {
   children: React.ReactElement;
   open?: boolean;
-  iconAlignment?: string;
+  align?: 'left' | 'right';
+  iconAlignment?: 'left' | 'right';
 }
 
 const SimpleDrawer = ({
   children,
   open,
+  align,
   iconAlignment,
 }: SimpleDrawerProps): React.ReactElement => {
   const [isOpen, setIsOpen] = useState(false);
@@ -30,6 +32,7 @@ const SimpleDrawer = ({
         onDrawerClose={toggleOpen}
         overlayClose={toggleOverlayClose}
         iconAlignment={iconAlignment}
+        align={align}
       >
         {children}
       </Drawer>

--- a/packages/ocean-react/src/Drawer/stories/Drawer.stories.mdx
+++ b/packages/ocean-react/src/Drawer/stories/Drawer.stories.mdx
@@ -46,6 +46,7 @@ import { Drawer } from '@useblu/ocean-react';
     name="playground"
     args={{
       open: false,
+      align: 'right',
       iconAlignment: 'right',
     }}
     argTypes={{
@@ -55,6 +56,11 @@ import { Drawer } from '@useblu/ocean-react';
       },
       iconAlignment: {
         name: 'iconAlignment',
+        options: ['right', 'left'],
+        control: { type: 'select' },
+      },
+      align: {
+        name: 'align',
         options: ['right', 'left'],
         control: { type: 'select' },
       },

--- a/packages/ocean-react/src/Drawer/stories/Drawer.stories.mdx
+++ b/packages/ocean-react/src/Drawer/stories/Drawer.stories.mdx
@@ -3,6 +3,7 @@ import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs';
 import Drawer from '../Drawer';
 
 import SimpleDrawer from '../examples/SimpleDrawer';
+import AttachedDrawer from '../examples/AttachedDrawer';
 import ContentPlaceholder from '../assets/contentPlaceholder.png';
 import Button from '../../Button';
 import Divider from '../../Divider';
@@ -135,6 +136,61 @@ import { Drawer } from '@useblu/ocean-react';
           </div>
         </div>
       </SimpleDrawer>
+    )}
+  </Story>
+</Canvas>
+
+## Attached Drawer
+
+<Canvas>
+  <Story
+    name="attached"
+    args={{
+      open: false,
+      align: 'right',
+      iconAlignment: 'right',
+    }}
+    argTypes={{
+      open: {
+        name: 'open',
+        control: 'boolean',
+      },
+      iconAlignment: {
+        name: 'iconAlignment',
+        options: ['right', 'left'],
+        control: { type: 'select' },
+      },
+      align: {
+        name: 'align',
+        options: ['right', 'left'],
+        control: { type: 'select' },
+      },
+    }}
+  >
+    {(props) => (
+      <AttachedDrawer {...props}>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            padding: '0 24px',
+          }}
+        >
+          <h3
+            style={{
+              fontFamily: 'Avenir',
+              fontSize: '20px',
+              fontWeight: '800',
+              lineHeight: '22px',
+              color: '#393B47',
+              margin: '0 0 8px 0',
+            }}
+          >
+            Drawer title
+          </h3>
+        </div>
+      </AttachedDrawer>
     )}
   </Story>
 </Canvas>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add align property to the drawer component to enable alignment on both the left and right sides.

Create an attach mode for the drawer component, allowing it to open on the side of another element, either on the right or left.

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Open drawer passing align and anchorEl, in props.

## Screenshots (if appropriate):

## Checklist:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] My changes work in Chrome, Edge, and Firefox
- [x] I have made corresponding changes to the documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed
