### PR TITLE
fix: adjust handle clicks on drawer and shortcut

### DIFF
--- a/packages/ocean-react/src/Drawer/Drawer.tsx
+++ b/packages/ocean-react/src/Drawer/Drawer.tsx
@@ -84,6 +84,7 @@ const Drawer = ({
       aria-hidden="true"
       onClick={handleOverlayClose}
       ref={drawerRef}
+      data-testId="drawer-overlay"
     >
       <div
         className={classNames(

--- a/packages/ocean-react/src/Drawer/Drawer.tsx
+++ b/packages/ocean-react/src/Drawer/Drawer.tsx
@@ -14,7 +14,7 @@ interface DrawerProps {
   children: React.ReactNode;
   open: boolean;
   onDrawerClose?(event: React.MouseEvent | React.KeyboardEvent): void;
-  overlayClose: () => void;
+  overlayClose: (event?: MouseEvent<HTMLDivElement>) => void;
   headerIcon?: React.ReactNode;
   align?: 'right' | 'left';
   iconAlignment?: 'right' | 'left';
@@ -34,6 +34,13 @@ const Drawer = ({
   onMouseOutDrawer,
 }: DrawerProps): React.ReactElement => {
   const drawerRef = useRef<HTMLDivElement>(null);
+
+  const handleOverlayClose = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      event.preventDefault();
+      overlayClose(event);
+    }
+  };
 
   const getAnchorPosition = useCallback(() => {
     if (!anchorEl?.current) return null;
@@ -75,7 +82,7 @@ const Drawer = ({
     <div
       className={classNames('ods-overlay', open && 'ods-overlay--open')}
       aria-hidden="true"
-      onClick={overlayClose}
+      onClick={handleOverlayClose}
       ref={drawerRef}
     >
       <div

--- a/packages/ocean-react/src/Drawer/__tests__/Drawer.test.tsx
+++ b/packages/ocean-react/src/Drawer/__tests__/Drawer.test.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import SimpleDrawer from '../../Drawer/examples/SimpleDrawer';
 import AttachedDrawer from '../../Drawer/examples/AttachedDrawer';
+import Drawer from '../../Drawer';
 
 jest.mock('@useblu/ocean-icons-react', () => ({
   XOutline: () => 'mock-x-outline-xvg',
@@ -130,3 +131,21 @@ test.each(['right', 'left'] as const)(
     expect(document.querySelector(`.ods-drawer--${align}`)).toBeInTheDocument();
   }
 );
+
+const TestComponent = () => {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <Drawer open={open} overlayClose={() => setOpen(false)}>
+      <p>Drawer content!</p>
+    </Drawer>
+  );
+};
+
+test('close the drawer clicking the overlay', () => {
+  render(<TestComponent />);
+
+  fireEvent.click(screen.getByTestId('drawer-overlay'));
+
+  expect(document.querySelector(`.ods-overlay`)?.className).toBe('ods-overlay');
+});

--- a/packages/ocean-react/src/Shortcut/Shortcut.tsx
+++ b/packages/ocean-react/src/Shortcut/Shortcut.tsx
@@ -5,7 +5,7 @@ import Badge from '../Badge';
 
 type ShortcutSize = 'tiny' | 'small' | 'medium' | 'large';
 
-export interface ShortcutProps {
+export type ShortcutProps = {
   icon: React.ReactNode;
   label: string;
   description?: string;
@@ -13,7 +13,7 @@ export interface ShortcutProps {
   blocked?: boolean;
   disabled?: boolean;
   count?: number;
-}
+} & React.ComponentPropsWithoutRef<'div'>;
 
 const Shortcut = ({
   icon,
@@ -23,6 +23,7 @@ const Shortcut = ({
   blocked = false,
   disabled = false,
   count,
+  ...rest
 }: ShortcutProps): React.ReactElement => (
   <div
     className={classNames(
@@ -31,6 +32,7 @@ const Shortcut = ({
       blocked && 'ods-shortcut--blocked',
       disabled && 'ods-shortcut--disabled'
     )}
+    {...rest}
   >
     {blocked && (
       <div className="ods-shortcut__blocked">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adjust overlay click on drawer, to only close when de overlay is clicked, not a child.
Add div behavior to shortcut

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] My changes work in Chrome, Edge, and Firefox
- [x] I have made corresponding changes to the documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed
