### PR TITLE
fix: breadcrumb map key prop

### DIFF
--- a/packages/ocean-core/src/components/breadcrumb.scss
+++ b/packages/ocean-core/src/components/breadcrumb.scss
@@ -7,6 +7,12 @@
     color: $color-interface-dark-up;
   }
 
+  div {
+    align-items: center;
+    display: flex;
+    gap: 4px;
+  }
+
   span,
   a {
     color: $color-interface-dark-up;

--- a/packages/ocean-react/src/Breadcrumb/Breadcrumb.tsx
+++ b/packages/ocean-react/src/Breadcrumb/Breadcrumb.tsx
@@ -22,13 +22,13 @@ const Breadcrumb = forwardRef<HTMLDivElement, BreadcrumbProps>(
         );
 
         return typeof item === 'string' ? (
-          <>
+          <div key={`string-item-${item}`}>
             <span>{item}</span> {showIcon}
-          </>
+          </div>
         ) : (
-          <>
+          <div key={`tag-item-${index + 1}`}>
             {item} {showIcon}
-          </>
+          </div>
         );
       })}
     </div>

--- a/packages/ocean-react/src/Breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/packages/ocean-react/src/Breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -17,33 +17,37 @@ test('renders breadcrumb with array elements', () => {
   );
 
   expect(screen.getByTestId('breadcrumb-test')).toMatchInlineSnapshot(`
-<div
-  class="ods-breadcrumb custom-class"
-  data-testid="breadcrumb-test"
->
-  <span>
-    item 1
-  </span>
-   
-  <svg
-    fill="currentColor"
-    height="12"
-    viewBox="0 0 20 20"
-    width="12"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      clip-rule="evenodd"
-      d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-      fill-rule="evenodd"
-    />
-  </svg>
-  <span>
-    item 2
-  </span>
-   
-</div>
-`);
+    <div
+      class="ods-breadcrumb custom-class"
+      data-testid="breadcrumb-test"
+    >
+      <div>
+        <span>
+          item 1
+        </span>
+         
+        <svg
+          fill="currentColor"
+          height="12"
+          viewBox="0 0 20 20"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </div>
+      <div>
+        <span>
+          item 2
+        </span>
+         
+      </div>
+    </div>
+  `);
 });
 
 test('renders breadcrumb with array string', () => {
@@ -57,48 +61,54 @@ test('renders breadcrumb with array string', () => {
   );
 
   expect(screen.getByTestId('breadcrumb-test')).toMatchInlineSnapshot(`
-  <div
-    class="ods-breadcrumb custom-class"
-    data-testid="breadcrumb-test"
-  >
-    <span>
-      item 1
-    </span>
-     
-    <svg
-      fill="currentColor"
-      height="12"
-      viewBox="0 0 20 20"
-      width="12"
-      xmlns="http://www.w3.org/2000/svg"
+    <div
+      class="ods-breadcrumb custom-class"
+      data-testid="breadcrumb-test"
     >
-      <path
-        clip-rule="evenodd"
-        d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-        fill-rule="evenodd"
-      />
-    </svg>
-    <span>
-      item 2
-    </span>
-     
-    <svg
-      fill="currentColor"
-      height="12"
-      viewBox="0 0 20 20"
-      width="12"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        clip-rule="evenodd"
-        d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-        fill-rule="evenodd"
-      />
-    </svg>
-    <span>
-      item 3
-    </span>
-     
-  </div>
+      <div>
+        <span>
+          item 1
+        </span>
+         
+        <svg
+          fill="currentColor"
+          height="12"
+          viewBox="0 0 20 20"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </div>
+      <div>
+        <span>
+          item 2
+        </span>
+         
+        <svg
+          fill="currentColor"
+          height="12"
+          viewBox="0 0 20 20"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </div>
+      <div>
+        <span>
+          item 3
+        </span>
+         
+      </div>
+    </div>
   `);
 });

--- a/packages/ocean-react/src/Breadcrumb/stories/Breadcrumb.stories.mdx
+++ b/packages/ocean-react/src/Breadcrumb/stories/Breadcrumb.stories.mdx
@@ -20,12 +20,16 @@ import { Breadcrumb } from '@useblu/ocean-react';
   <Story name="usage">
     <Breadcrumb
       items={[
-        <span>Home</span>,
-        <span>Page 1</span>,
-        <span>Page 2</span>,
-        <span>Page 3</span>,
-        <span>Page 4</span>,
-        <span>Current page</span>,
+        <a href="/" rel="noopener noreferrer">
+          Home
+        </a>,
+        <a href={`/page-1`} rel="noopener noreferrer">
+          Page 1
+        </a>,
+        <a href={`/page-2`} rel="noopener noreferrer">
+          Page 2
+        </a>,
+        'Page 4',
       ]}
     />
   </Story>
@@ -45,7 +49,18 @@ If that's not sufficient, you can check the [implementation of the component](ht
   <Story
     name="playground"
     args={{
-      items: ['Home', 'Page 1', 'Page 2', 'Page 3', 'Page 4', 'Current page'],
+      items: [
+        <a href="/" rel="noopener noreferrer">
+          Home
+        </a>,
+        <a href={`/page-1`} rel="noopener noreferrer">
+          Page 1
+        </a>,
+        <a href={`/page-2`} rel="noopener noreferrer">
+          Page 2
+        </a>,
+        'Page 4',
+      ],
     }}
     argTypes={{
       items: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adiciona a key prop na renderização do map no componente breadcrumb

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Screenshots (if appropriate):
![image](https://github.com/ocean-ds/ocean-web/assets/62384394/dbc21a78-7e24-4dab-9fdf-796f73491fec)

## Checklist:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] My changes work in Chrome, Edge, and Firefox
- [x] I have made corresponding changes to the documentation (if appropriate)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed
