### PR TITLE
fix: adjusts on Date component

### DIFF
--- a/packages/ocean-core/src/components/breadcrumb.scss
+++ b/packages/ocean-core/src/components/breadcrumb.scss
@@ -1,7 +1,7 @@
 .ods-breadcrumb {
   align-items: center;
   display: flex;
-  gap: 8px;
+  gap: 4px;
 
   svg {
     color: $color-interface-dark-up;

--- a/packages/ocean-react/src/Date/DateHeader.tsx
+++ b/packages/ocean-react/src/Date/DateHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import classNames from 'classnames';
 
 import { format, Locale } from 'date-fns';
@@ -17,6 +17,21 @@ const DatePickerHeader: React.FC<IProps> = ({
 }) => {
   const { goToMonth, nextMonth, previousMonth } = useNavigation();
 
+  const [selectedMonth, setSelectedMonth] = useState<Date>(displayMonth);
+
+  const handlePreviousMonthClick = () => {
+    if (previousMonth) {
+      goToMonth(previousMonth);
+      setSelectedMonth(previousMonth);
+    }
+  };
+
+  const handleNextMonthClick = () => {
+    if (nextMonth) {
+      goToMonth(nextMonth);
+      setSelectedMonth(nextMonth);
+    }
+  };
   return (
     <div className="ods-date__caption">
       <IconButton
@@ -28,12 +43,12 @@ const DatePickerHeader: React.FC<IProps> = ({
           'ods-date__navButtonPrev-datepicker': mode === 'single',
         })}
         disabled={!previousMonth}
-        onClick={() => previousMonth && goToMonth(previousMonth)}
+        onClick={handlePreviousMonthClick}
       >
         <ChevronLeft size={20} />
       </IconButton>
       <h2 data-testid="calendar-caption-month">
-        {format(displayMonth, 'MMMM yyyy', { locale })}
+        {format(selectedMonth, 'MMMM yyyy', { locale })}
       </h2>
       <IconButton
         type="button"
@@ -44,7 +59,7 @@ const DatePickerHeader: React.FC<IProps> = ({
           'ods-date__navButtonNext-datepicker': mode === 'single',
         })}
         disabled={!nextMonth}
-        onClick={() => nextMonth && goToMonth(nextMonth)}
+        onClick={handleNextMonthClick}
       >
         <ChevronRight size={20} />
       </IconButton>

--- a/packages/ocean-react/src/Date/DatePicker.tsx
+++ b/packages/ocean-react/src/Date/DatePicker.tsx
@@ -45,6 +45,7 @@ const DatePickerSingle = React.forwardRef<
       disabledDays,
       formatDay,
       handleCloseByOutside,
+      currentMonthToDisplay,
     } = useDatePicker({ value, onSelect, startsToday, locale });
 
     return (
@@ -102,6 +103,7 @@ const DatePickerSingle = React.forwardRef<
                   formatters={{ formatDay }}
                   selected={selectedDay}
                   disabled={disabledDays}
+                  defaultMonth={currentMonthToDisplay}
                   components={{
                     Caption: ({ displayMonth }: CaptionProps) =>
                       DateHeader({

--- a/packages/ocean-react/src/Date/DateRange.tsx
+++ b/packages/ocean-react/src/Date/DateRange.tsx
@@ -39,12 +39,13 @@ const DatePickerRange = React.forwardRef<HTMLDivElement, DatePickerProps>(
       inputPlaceholder,
       handleDayMouseEnter,
       handleDayClick,
+      handleDisplayMonth,
       inputChange,
       createHandleToggleClick,
       disabledDays,
       formatDay,
-
       handleCloseByOutside,
+      currentMonthToDisplay,
     } = useDateRange({ values, onSelect, startsToday, locale });
 
     return (
@@ -139,9 +140,14 @@ const DatePickerRange = React.forwardRef<HTMLDivElement, DatePickerProps>(
                   formatters={{ formatDay }}
                   selected={selectedDays}
                   disabled={disabledDays}
+                  defaultMonth={currentMonthToDisplay}
                   components={{
-                    Caption: ({ displayMonth }: CaptionProps) =>
-                      DatePickerHeader({ displayMonth, locale: localeOption }),
+                    Caption: ({ displayMonth }: CaptionProps) => (
+                      <DatePickerHeader
+                        locale={localeOption}
+                        displayMonth={handleDisplayMonth(displayMonth)}
+                      />
+                    ),
                   }}
                 />
               </div>

--- a/packages/ocean-react/src/Date/hooks/useDatePicker.ts
+++ b/packages/ocean-react/src/Date/hooks/useDatePicker.ts
@@ -1,11 +1,9 @@
 import React from 'react';
 import * as DateFns from 'date-fns';
-
 import ptBr from 'date-fns/locale/pt-BR';
+import { ClassNames } from 'react-day-picker';
 
-import { ClassNames, DateFormatter } from 'react-day-picker';
-
-import { DatePickerSingleProps } from '../types/DatePicker.types';
+import { IDatePickerProps, IDatePickerReturn } from '../types/DatePicker.types';
 
 import {
   handleValidateStartsToday,
@@ -13,29 +11,6 @@ import {
   formatDay,
   getInputPlaceholder,
 } from '../utils/dateUtils';
-
-type IDatePickerProps = Pick<
-  DatePickerSingleProps,
-  'value' | 'onSelect' | 'startsToday' | 'locale'
->;
-
-type IDatePickerReturn = {
-  input1Ref: React.Ref<HTMLInputElement>;
-  input2Ref: React.Ref<HTMLInputElement>;
-  showDayPicker: boolean;
-  selectedDay: Date;
-  CustomStyles: ClassNames;
-  localeOption: DateFns.Locale;
-  currentField: string;
-  inputPlaceholder: string;
-  handleDayClick: (day: Date) => void;
-  inputChange: ({ target }: React.ChangeEvent<HTMLInputElement>) => void;
-  createHandleToggleClick: (fieldId: string) => void;
-  disabledDays: (day: Date) => boolean;
-  formatDay: DateFormatter;
-  handleCloseByOutside: () => void;
-  currentMonthToDisplay: Date | undefined;
-};
 
 export default function useDatePickerSingle({
   value,

--- a/packages/ocean-react/src/Date/hooks/useDatePicker.ts
+++ b/packages/ocean-react/src/Date/hooks/useDatePicker.ts
@@ -34,6 +34,7 @@ type IDatePickerReturn = {
   disabledDays: (day: Date) => boolean;
   formatDay: DateFormatter;
   handleCloseByOutside: () => void;
+  currentMonthToDisplay: Date | undefined;
 };
 
 export default function useDatePickerSingle({
@@ -53,6 +54,8 @@ export default function useDatePickerSingle({
 
   const [showDayPicker, setShowDayPicker] = React.useState(false);
   const [currentField, setCurrentField] = React.useState<string>('');
+  const [currentMonthToDisplay, setCurrentMonthToDisplay] =
+    React.useState<Date>();
   const [datePickerCache, setDatePickerCache] = React.useState<string>('');
 
   const fromDate = DateFns.parse(value || '', localeDateFormat, new Date());
@@ -70,6 +73,7 @@ export default function useDatePickerSingle({
     if (!(startsToday && handleValidateStartsToday(startsToday, day))) {
       const formattedDay = DateFns.format(day, localeDateFormat);
 
+      updateCurrentMonth(formattedDay);
       updateState(formattedDay, true);
       setCurrentField('');
       setShowDayPicker(false);
@@ -113,6 +117,12 @@ export default function useDatePickerSingle({
     }
   };
 
+  const updateCurrentMonth = (date: string) => {
+    const parsedDate = DateFns.parse(date, 'dd/MM/yyyy', new Date());
+
+    setCurrentMonthToDisplay(parsedDate);
+  };
+
   const CustomStyles: ClassNames = {
     root: 'ods-date__calendar ods-date_calendar_m1',
     caption: 'ods-date__caption',
@@ -151,5 +161,6 @@ export default function useDatePickerSingle({
     disabledDays,
     formatDay,
     handleCloseByOutside,
+    currentMonthToDisplay,
   };
 }

--- a/packages/ocean-react/src/Date/hooks/useDateRange.ts
+++ b/packages/ocean-react/src/Date/hooks/useDateRange.ts
@@ -3,8 +3,12 @@ import * as DateFns from 'date-fns';
 
 import ptBr from 'date-fns/locale/pt-BR';
 
-import { DateRange, ClassNames, DateFormatter } from 'react-day-picker';
-import { DatePickerProps, DatePickerFields } from '../types/DateRange.types';
+import { DateRange, ClassNames } from 'react-day-picker';
+import {
+  DatePickerFields,
+  IDatePickerReturn,
+  IDatePickerProps,
+} from '../types/DateRange.types';
 
 import {
   handleValidateStartsToday,
@@ -12,33 +16,6 @@ import {
   formatDay,
   getInputPlaceholder,
 } from '../utils/dateUtils';
-
-type IDatePickerProps = Pick<
-  DatePickerProps,
-  'values' | 'onSelect' | 'startsToday' | 'locale'
->;
-
-type IDatePickerReturn = {
-  input1Ref: React.Ref<HTMLInputElement>;
-  input2Ref: React.Ref<HTMLInputElement>;
-  showDayPicker: boolean;
-  fromDate: Date;
-  toDate: Date;
-  selectedDays: DateRange;
-  CustomStyles: ClassNames;
-  localeOption: DateFns.Locale;
-  currentField: string;
-  inputPlaceholder: string;
-  handleDayMouseEnter: (day: Date) => void;
-  handleDayClick: (day: Date) => void;
-  inputChange: ({ target }: React.ChangeEvent<HTMLInputElement>) => void;
-  createHandleToggleClick: (fieldId: string) => void;
-  disabledDays: (day: Date) => boolean;
-  formatDay: DateFormatter;
-  handleCloseByOutside: () => void;
-  handleDisplayMonth: (displayMonth: Date) => Date;
-  currentMonthToDisplay: Date | undefined;
-};
 
 export default function useDatePicker({
   values,

--- a/packages/ocean-react/src/Date/hooks/useDateRange.ts
+++ b/packages/ocean-react/src/Date/hooks/useDateRange.ts
@@ -114,17 +114,17 @@ export default function useDatePicker({
 
   const updateCurrentMonth = (date: string) => {
     const parsedDate = DateFns.parse(date, 'dd/MM/yyyy', new Date());
-
     setCurrentMonthToDisplay(parsedDate);
   };
 
   const isValidDate = (date: Date | undefined): boolean =>
     date instanceof Date && !Number.isNaN(date.getTime());
 
+  const getSelectedDate = () =>
+    firstInputClicked ? selectedDays.from : selectedDays.to;
+
   const handleDisplayMonth = (displayMonth: Date) => {
-    const selectedDate = firstInputClicked
-      ? selectedDays.from
-      : selectedDays.to;
+    const selectedDate = getSelectedDate();
     const monthToShowOnHeader = isValidDate(selectedDate)
       ? selectedDate
       : undefined;
@@ -138,14 +138,18 @@ export default function useDatePicker({
     const isValidEndDate =
       fieldId === 'end-date' && isValidDate(selectedDays.to);
 
-    if (isValidStartDate) {
-      updateCurrentMonth(values.from);
-      setFirstInputClicked(true);
-    }
+    const updateValuesAndInputClicked = (
+      date: string,
+      isFirstInputClicked: boolean
+    ) => {
+      updateCurrentMonth(date);
+      setFirstInputClicked(isFirstInputClicked);
+    };
 
-    if (isValidEndDate) {
-      updateCurrentMonth(values.to);
-      setFirstInputClicked(false);
+    if (isValidStartDate) {
+      updateValuesAndInputClicked(values.from, true);
+    } else if (isValidEndDate) {
+      updateValuesAndInputClicked(values.to, false);
     }
 
     setShowDayPicker(!showDayPicker);

--- a/packages/ocean-react/src/Date/types/DatePicker.types.ts
+++ b/packages/ocean-react/src/Date/types/DatePicker.types.ts
@@ -1,3 +1,6 @@
+import * as DateFns from 'date-fns';
+
+import { ClassNames, DateFormatter } from 'react-day-picker';
 import { DatePickerProps } from './DateRange.types';
 
 export type DatePickerSingleProps = {
@@ -5,3 +8,26 @@ export type DatePickerSingleProps = {
   value: string | undefined;
   onSelect: (date: string) => void;
 } & Omit<DatePickerProps, 'labels' | 'values' | 'onSelect'>;
+
+export type IDatePickerProps = Pick<
+  DatePickerSingleProps,
+  'value' | 'onSelect' | 'startsToday' | 'locale'
+>;
+
+export type IDatePickerReturn = {
+  input1Ref: React.Ref<HTMLInputElement>;
+  input2Ref: React.Ref<HTMLInputElement>;
+  showDayPicker: boolean;
+  selectedDay: Date;
+  CustomStyles: ClassNames;
+  localeOption: DateFns.Locale;
+  currentField: string;
+  inputPlaceholder: string;
+  handleDayClick: (day: Date) => void;
+  inputChange: ({ target }: React.ChangeEvent<HTMLInputElement>) => void;
+  createHandleToggleClick: (fieldId: string) => void;
+  disabledDays: (day: Date) => boolean;
+  formatDay: DateFormatter;
+  handleCloseByOutside: () => void;
+  currentMonthToDisplay: Date | undefined;
+};

--- a/packages/ocean-react/src/Date/types/DateRange.types.ts
+++ b/packages/ocean-react/src/Date/types/DateRange.types.ts
@@ -1,6 +1,7 @@
 import React from 'react';
-
+import * as DateFns from 'date-fns';
 import { Locale } from 'date-fns';
+import { DateRange, ClassNames, DateFormatter } from 'react-day-picker';
 
 export type DatePickerFields = {
   from: string;
@@ -67,3 +68,30 @@ export type DatePickerProps = {
    */
   className?: string;
 } & React.ComponentPropsWithoutRef<'div'>;
+
+export type IDatePickerProps = Pick<
+  DatePickerProps,
+  'values' | 'onSelect' | 'startsToday' | 'locale'
+>;
+
+export type IDatePickerReturn = {
+  input1Ref: React.Ref<HTMLInputElement>;
+  input2Ref: React.Ref<HTMLInputElement>;
+  showDayPicker: boolean;
+  fromDate: Date;
+  toDate: Date;
+  selectedDays: DateRange;
+  CustomStyles: ClassNames;
+  localeOption: DateFns.Locale;
+  currentField: string;
+  inputPlaceholder: string;
+  handleDayMouseEnter: (day: Date) => void;
+  handleDayClick: (day: Date) => void;
+  inputChange: ({ target }: React.ChangeEvent<HTMLInputElement>) => void;
+  createHandleToggleClick: (fieldId: string) => void;
+  disabledDays: (day: Date) => boolean;
+  formatDay: DateFormatter;
+  handleCloseByOutside: () => void;
+  handleDisplayMonth: (displayMonth: Date) => Date;
+  currentMonthToDisplay: Date | undefined;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When a user selects a date and clicks back into the field, the month shown on the calendar is not the one that was selected

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

In Storybook, select DateRange or Datepicker, choose a date, and click on the input again; the month shown on the calendar should be the one corresponding to the selected date.

## Screenshots (if appropriate):

Before fix
![96008340-4636-493B-A82F-5C2FC781AAAE](https://github.com/ocean-ds/ocean-web/assets/102989712/11a4505e-7eb3-4152-9a9c-eb95ae35928f)

After
![image](https://github.com/ocean-ds/ocean-web/assets/102989712/5bee15fc-57a5-43ec-94da-05dc416f9d11)

https://github.com/ocean-ds/ocean-web/assets/102989712/b70a683e-6742-4a1e-be06-3800e7c3752c



## Checklist:

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] My changes work in Chrome, Edge, and Firefox
- [X] I have made corresponding changes to the documentation (if appropriate)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All new and existing tests passed
