### PR TITLE
fix: tag position and limit props to accept only tag or count prop

### DIFF
--- a/packages/ocean-core/src/components/_shortcut.scss
+++ b/packages/ocean-core/src/components/_shortcut.scss
@@ -106,22 +106,22 @@
 
   &__badge {
     position: absolute;
-    right: 8px;
-    top: 8px;
+    right: $spacing-inline-xxs;
+    top: $spacing-inline-xxs;
   }
 
   &__tag {
     position: absolute;
-    right: 8px;
-    top: 8px;
+    right: $spacing-inline-xxs;
+    top: $spacing-inline-xxs;
   }
 
   &__blocked {
     color: $color-interface-dark-up;
     height: $font-size-xs;
     position: absolute;
-    right: 8px;
-    top: 8px;
+    right: $spacing-inline-xxs;
+    top: $spacing-inline-xxs;
     width: $font-size-xs;
 
     svg {

--- a/packages/ocean-core/src/components/_shortcut.scss
+++ b/packages/ocean-core/src/components/_shortcut.scss
@@ -104,12 +104,7 @@
     font-size: $font-size-xxxs;
   }
 
-  &__badge {
-    position: absolute;
-    right: $spacing-inline-xxs;
-    top: $spacing-inline-xxs;
-  }
-
+  &__badge,
   &__tag {
     position: absolute;
     right: $spacing-inline-xxs;

--- a/packages/ocean-core/src/components/_shortcut.scss
+++ b/packages/ocean-core/src/components/_shortcut.scss
@@ -110,6 +110,12 @@
     top: 8px;
   }
 
+  &__tag {
+    position: absolute;
+    right: 8px;
+    top: 8px;
+  }
+
   &__blocked {
     color: $color-interface-dark-up;
     height: $font-size-xs;

--- a/packages/ocean-docs/docs/components/shortcut.mdx
+++ b/packages/ocean-docs/docs/components/shortcut.mdx
@@ -168,9 +168,11 @@ Veja todos os estados:
 
 ## Badge e Tag
 
-O Shortcut pode exibir um badge numérico ou uma tag:
+O Shortcut pode exibir um badge numérico **ou** uma tag. As propriedades `count` e `tag` são mutuamente exclusivas - você deve usar apenas uma por vez.
 
 ### Com Badge
+
+O badge exibe um número e aparece no canto superior do atalho:
 
 ```tsx live
 <Shortcut label="Com Badge" icon={<PlaceholderOutline />} count={5} />
@@ -178,18 +180,31 @@ O Shortcut pode exibir um badge numérico ou uma tag:
 
 ### Com Tag
 
-```tsx live
-<Shortcut label="Com Tag" icon={<PlaceholderOutline />} tag="Novo" />
-```
+A tag exibe um texto e sua posição depende da orientação do atalho:
 
-### Com Badge e Tag
+#### Tag em orientação horizontal
+
+Na orientação horizontal (padrão), a tag aparece ao lado do label, dentro do conteúdo:
 
 ```tsx live
 <Shortcut
-  label="Com Badge e Tag"
+  label="Com Tag"
   icon={<PlaceholderOutline />}
-  count={12}
-  tag="Importante"
+  tag="Novo"
+  orientation="horizontal"
+/>
+```
+
+#### Tag em orientação vertical
+
+Na orientação vertical, a tag aparece acima do conteúdo:
+
+```tsx live
+<Shortcut
+  label="Com Tag"
+  icon={<PlaceholderOutline />}
+  tag="Novo"
+  orientation="vertical"
 />
 ```
 
@@ -199,7 +214,14 @@ Exemplos de Badge e Tag:
   storyId="components-shortcut--with-badge"
   height={200}
   showToolbar={false}
-  title="Shortcut - Badge e Tag"
+  title="Shortcut - Badge"
+/>
+
+<StorybookEmbed
+  storyId="components-shortcut--with-tag"
+  height={200}
+  showToolbar={false}
+  title="Shortcut - Tag com diferentes orientações"
 />
 
 ## Full Width
@@ -235,19 +257,19 @@ Comparação Full Width:
 
 ### Props
 
-| Prop          | Tipo                            | Padrão         | Descrição                                     |
-| ------------- | ------------------------------- | -------------- | --------------------------------------------- |
-| `label`       | `string`                        | -              | Texto do label do atalho                      |
-| `description` | `string`                        | -              | Descrição adicional (apenas para size medium) |
-| `icon`        | `ReactNode`                     | -              | Ícone do atalho                               |
-| `size`        | `'tiny' \| 'small' \| 'medium'` | `'medium'`     | O tamanho do componente de atalho             |
-| `orientation` | `'horizontal' \| 'vertical'`    | `'horizontal'` | A orientação do layout do atalho              |
-| `blocked`     | `boolean`                       | `false`        | Define se o atalho está bloqueado             |
-| `disabled`    | `boolean`                       | `false`        | Desabilita o atalho                           |
-| `fullWidth`   | `boolean`                       | `false`        | Faz o atalho ocupar toda a largura disponível |
-| `count`       | `number`                        | -              | Número exibido no badge do atalho             |
-| `tag`         | `string`                        | -              | Tag exibida no atalho                         |
-| `className`   | `string`                        | -              | Classes CSS adicionais                        |
+| Prop          | Tipo                            | Padrão         | Descrição                                                                                 |
+| ------------- | ------------------------------- | -------------- | ----------------------------------------------------------------------------------------- |
+| `label`       | `string`                        | -              | Texto do label do atalho                                                                  |
+| `description` | `string`                        | -              | Descrição adicional (apenas para size medium)                                             |
+| `icon`        | `ReactNode`                     | -              | Ícone do atalho                                                                           |
+| `size`        | `'tiny' \| 'small' \| 'medium'` | `'medium'`     | O tamanho do componente de atalho                                                         |
+| `orientation` | `'horizontal' \| 'vertical'`    | `'horizontal'` | A orientação do layout do atalho                                                          |
+| `blocked`     | `boolean`                       | `false`        | Define se o atalho está bloqueado                                                         |
+| `disabled`    | `boolean`                       | `false`        | Desabilita o atalho                                                                       |
+| `fullWidth`   | `boolean`                       | `false`        | Faz o atalho ocupar toda a largura disponível                                             |
+| `count`       | `number`                        | -              | Número exibido no badge do atalho (mutuamente exclusivo com `tag`)                        |
+| `tag`         | `string`                        | -              | Tag exibida no atalho (mutuamente exclusivo com `count`). Posição varia com `orientation` |
+| `className`   | `string`                        | -              | Classes CSS adicionais                                                                    |
 
 ### Classes CSS
 
@@ -279,6 +301,7 @@ O componente Shortcut utiliza as seguintes classes CSS para customização:
 | `.ods-shortcut__label`               | Texto do label                        |
 | `.ods-shortcut__description`         | Texto da descrição                    |
 | `.ods-shortcut__badge`               | Container do badge numérico           |
+| `.ods-shortcut__tag`                 | Container da tag (posição varia)      |
 | `.ods-shortcut__blocked`             | Container do ícone de bloqueio        |
 
 ## Acessibilidade
@@ -304,13 +327,15 @@ O componente Shortcut utiliza as seguintes classes CSS para customização:
 - Use ícones que representem visualmente a funcionalidade
 - Use descrições apenas quando necessário para esclarecimento
 - Use badges para notificações numéricas importantes
-- Use tags para destacar status ou categorias
+- Use tags para destacar status ou categorias importantes
+- Escolha a orientação adequada ao layout (horizontal ou vertical)
+- Considere a posição da tag ao escolher a orientação
 
 ### ❌ Não faça
 
 - Não use textos muito longos nos labels
 - Não use ícones que não representem a funcionalidade
-- Não use múltiplos badges ou tags simultaneamente
+- Não use badge (`count`) e tag (`tag`) ao mesmo tempo - são mutuamente exclusivos
 - Não omita o estado `disabled` quando apropriado
 - Não use Shortcut para ações que não são navegação
 

--- a/packages/ocean-react/src/Shortcut/Shortcut.tsx
+++ b/packages/ocean-react/src/Shortcut/Shortcut.tsx
@@ -61,7 +61,7 @@ const Shortcut = ({
         count={count}
       />
     ) : null}
-    {!blocked && tag && (
+    {!blocked && tag && orientation === 'vertical' && (
       <Tag className="ods-shortcut__tag" variant="highlight" type="important">
         {tag}
       </Tag>
@@ -81,6 +81,11 @@ const Shortcut = ({
       >
         {label}
       </h5>
+      {tag && orientation === 'horizontal' && (
+        <Tag variant="highlight" type="important">
+          {tag}
+        </Tag>
+      )}
     </div>
     {size === 'medium' && description && (
       <span

--- a/packages/ocean-react/src/Shortcut/Shortcut.tsx
+++ b/packages/ocean-react/src/Shortcut/Shortcut.tsx
@@ -57,7 +57,7 @@ const Shortcut = ({
       <Badge
         className="ods-shortcut__badge"
         variation="small"
-        color="alert"
+        color={disabled ? 'neutral' : 'alert'}
         count={count}
       />
     ) : null}

--- a/packages/ocean-react/src/Shortcut/Shortcut.tsx
+++ b/packages/ocean-react/src/Shortcut/Shortcut.tsx
@@ -53,7 +53,7 @@ const Shortcut = ({
         <LockClosed />
       </div>
     )}
-    {count ? (
+    {!blocked && count ? (
       <Badge
         className="ods-shortcut__badge"
         variation="small"
@@ -81,6 +81,11 @@ const Shortcut = ({
       >
         {label}
       </h5>
+      {!blocked && tag && (
+        <Tag variant="highlight" type="important">
+          {tag}
+        </Tag>
+      )}
     </div>
     {size === 'medium' && description && (
       <span

--- a/packages/ocean-react/src/Shortcut/Shortcut.tsx
+++ b/packages/ocean-react/src/Shortcut/Shortcut.tsx
@@ -6,6 +6,11 @@ import Tag from '../Tag/Tag';
 
 type ShortcutSize = 'tiny' | 'small' | 'medium';
 
+type ExclusiveTagOrCount =
+  | { tag: string; count?: never }
+  | { tag?: never; count: number }
+  | { tag?: never; count?: never };
+
 export type ShortcutProps = {
   icon: React.ReactNode;
   label: string;
@@ -13,11 +18,10 @@ export type ShortcutProps = {
   size?: ShortcutSize;
   blocked?: boolean;
   disabled?: boolean;
-  count?: number;
   fullWidth?: boolean;
   orientation?: 'horizontal' | 'vertical';
-  tag?: string;
-} & React.ComponentPropsWithoutRef<'div'>;
+} & ExclusiveTagOrCount &
+  React.ComponentPropsWithoutRef<'div'>;
 
 const Shortcut = ({
   icon,
@@ -57,6 +61,11 @@ const Shortcut = ({
         count={count}
       />
     ) : null}
+    {tag && (
+      <Tag className="ods-shortcut__tag" variant="highlight" type="important">
+        {tag}
+      </Tag>
+    )}
     <div
       className={classNames(
         'ods-shortcut__content',
@@ -72,11 +81,6 @@ const Shortcut = ({
       >
         {label}
       </h5>
-      {tag && (
-        <Tag variant="highlight" type="important">
-          {tag}
-        </Tag>
-      )}
     </div>
     {size === 'medium' && description && (
       <span

--- a/packages/ocean-react/src/Shortcut/Shortcut.tsx
+++ b/packages/ocean-react/src/Shortcut/Shortcut.tsx
@@ -81,11 +81,6 @@ const Shortcut = ({
       >
         {label}
       </h5>
-      {!blocked && tag && (
-        <Tag variant="highlight" type="important">
-          {tag}
-        </Tag>
-      )}
     </div>
     {size === 'medium' && description && (
       <span

--- a/packages/ocean-react/src/Shortcut/Shortcut.tsx
+++ b/packages/ocean-react/src/Shortcut/Shortcut.tsx
@@ -61,7 +61,7 @@ const Shortcut = ({
         count={count}
       />
     ) : null}
-    {tag && (
+    {!blocked && tag && (
       <Tag className="ods-shortcut__tag" variant="highlight" type="important">
         {tag}
       </Tag>

--- a/packages/ocean-react/src/Shortcut/stories/Shortcut.stories.tsx
+++ b/packages/ocean-react/src/Shortcut/stories/Shortcut.stories.tsx
@@ -233,7 +233,29 @@ export const WithBadge: Story = {
   render: () => (
     <HorizontalLayout align="flex-start">
       <Shortcut label="Com Badge" icon={<PlaceholderOutline />} count={5} />
+      <Shortcut
+        label="Com Badge"
+        icon={<PlaceholderOutline />}
+        count={5}
+        orientation="vertical"
+      />
+    </HorizontalLayout>
+  ),
+};
+
+export const WithTag: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <HorizontalLayout align="flex-start">
       <Shortcut label="Com Tag" icon={<PlaceholderOutline />} tag="Novo" />
+      <Shortcut
+        label="Com Tag"
+        icon={<PlaceholderOutline />}
+        tag="Novo"
+        orientation="vertical"
+      />
     </HorizontalLayout>
   ),
 };

--- a/packages/ocean-react/src/Shortcut/stories/Shortcut.stories.tsx
+++ b/packages/ocean-react/src/Shortcut/stories/Shortcut.stories.tsx
@@ -234,12 +234,6 @@ export const WithBadge: Story = {
     <HorizontalLayout align="flex-start">
       <Shortcut label="Com Badge" icon={<PlaceholderOutline />} count={5} />
       <Shortcut label="Com Tag" icon={<PlaceholderOutline />} tag="Novo" />
-      <Shortcut
-        label="Com Badge e Tag"
-        icon={<PlaceholderOutline />}
-        count={12}
-        tag="Importante"
-      />
     </HorizontalLayout>
   ),
 };
@@ -292,19 +286,6 @@ export const AllVariants: Story = {
             label="Desabilitado"
             icon={<PlaceholderOutline />}
             disabled
-          />
-        </HorizontalLayout>
-      </Section>
-
-      <Section title="Com Badge e Tag:">
-        <HorizontalLayout align="flex-start">
-          <Shortcut label="Com Badge" icon={<PlaceholderOutline />} count={5} />
-          <Shortcut label="Com Tag" icon={<PlaceholderOutline />} tag="Novo" />
-          <Shortcut
-            label="Com Badge e Tag"
-            icon={<PlaceholderOutline />}
-            count={12}
-            tag="Importante"
           />
         </HorizontalLayout>
       </Section>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR ajusts tag position and a limitation to permit only tag or count prop.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Just render Shortcut component and try to pass count and tag props.

## Screenshots (if appropriate):

<img width="318" height="130" alt="image" src="https://github.com/user-attachments/assets/bcec53cb-2221-4ee0-91f6-314679b33c7e" />

<img width="318" height="130" alt="image" src="https://github.com/user-attachments/assets/1d071229-dd7d-414a-ac87-454bfcc09a78" />

## Checklist:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] My changes work in Chrome, Edge, and Firefox
- [x] I have made corresponding changes to the documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed
