### PR TITLE
feat(TransactionListItem): add isInverted prop for typography hierarchy (BAN-52)

### DIFF
--- a/packages/ocean-core/src/components/_list-item.scss
+++ b/packages/ocean-core/src/components/_list-item.scss
@@ -217,3 +217,12 @@
     margin-left: $spacing-inline-xxs;
   }
 }
+
+.ods-transaction-list-item--inverted {
+  .ods-transaction-list-item__level1 {
+    font-size: $font-size-xxs;
+  }
+  .ods-transaction-list-item__level2 {
+    font-size: $font-size-xs;
+  }
+}

--- a/packages/ocean-docs/docs/components/transactionlistitem.mdx
+++ b/packages/ocean-docs/docs/components/transactionlistitem.mdx
@@ -283,6 +283,39 @@ Para mostrar detalhes expandíveis:
   title="TransactionListItem - Exemplo Completo"
 />
 
+## Hierarquia invertida
+
+Use `isInverted` para inverter a hierarquia tipográfica entre Level 1 e Level 2. Quando ativado, Level 1 (children) recebe fonte menor (description) e Level 2 recebe fonte maior (paragraph), dando destaque visual ao beneficiário:
+
+```tsx live
+<List>
+  <TransactionListItem
+    icon={<Reply />}
+    level2="Transferência PIX"
+    value="R$ 250,00"
+    positive
+  >
+    João da Silva
+  </TransactionListItem>
+  <TransactionListItem
+    icon={<Reply />}
+    level2="Transferência PIX"
+    value="R$ 250,00"
+    positive
+    isInverted
+  >
+    João da Silva
+  </TransactionListItem>
+</List>
+```
+
+<StorybookEmbed
+  storyId="components-list-transactionlistitem--inverted"
+  height={300}
+  showToolbar={false}
+  title="TransactionListItem - Hierarquia Invertida"
+/>
+
 ## Estados
 
 ### Estados de interação
@@ -322,6 +355,7 @@ Para mostrar detalhes expandíveis:
 | `subItens`    | `React.ReactNode` | -       | Subitens aninhados                        |
 | `readOnly`    | `boolean`         | `false` | Define se o item é somente leitura        |
 | `isLoading`   | `boolean`         | `false` | Exibe estado de carregamento              |
+| `isInverted`  | `boolean`         | `false` | Inverte a hierarquia tipográfica entre Level 1 e Level 2 |
 | `className`   | `string`          | -       | Classes CSS adicionais                    |
 | `onClick`     | `function`        | -       | Função chamada ao clicar no item          |
 
@@ -342,6 +376,7 @@ Para mostrar detalhes expandíveis:
 | `.ods-transaction-list-item__tags`            | Estilos aplicados às tags                        |
 | `.ods-transaction-list-item__time`            | Estilos aplicados ao horário                     |
 | `.ods-transaction-list-item__sub-itens`       | Estilos aplicados ao container de subitens       |
+| `.ods-transaction-list-item--inverted`        | Inverte tamanhos de fonte entre Level 1 e Level 2 |
 
 ## Acessibilidade
 

--- a/packages/ocean-react/src/TransactionListItem/TransactionListItem.tsx
+++ b/packages/ocean-react/src/TransactionListItem/TransactionListItem.tsx
@@ -42,6 +42,12 @@ export type TransactionListItemProps = {
   withChevron?: boolean;
   readOnly?: boolean;
   isLoading?: boolean;
+  /**
+   * Inverts the typography hierarchy between level1 and level2.
+   * When true, level1 uses description (smaller) and level2 uses paragraph (larger) typography.
+   * @default false
+   */
+  isInverted?: boolean;
 } & React.ComponentPropsWithoutRef<'div'>;
 
 const TransactionListItem = React.forwardRef<
@@ -64,6 +70,7 @@ const TransactionListItem = React.forwardRef<
       withChevron,
       readOnly,
       isLoading,
+      isInverted = false,
       ...rest
     },
     ref
@@ -75,6 +82,7 @@ const TransactionListItem = React.forwardRef<
         { 'ods-transaction-list-item--chevron': withChevron },
         { 'ods-transaction-list-item--readonly': readOnly },
         { 'ods-transaction-list-item--isloading': isLoading },
+        { 'ods-transaction-list-item--inverted': isInverted },
         className
       )}
       {...rest}

--- a/packages/ocean-react/src/TransactionListItem/__tests__/TransactionListItem.test.tsx
+++ b/packages/ocean-react/src/TransactionListItem/__tests__/TransactionListItem.test.tsx
@@ -127,6 +127,20 @@ test('renders default element properly with all possible information', () => {
   `);
 });
 
+test('renders without inverted class by default', () => {
+  setup();
+
+  const element = document.querySelector('.ods-transaction-list-item');
+  expect(element).not.toHaveClass('ods-transaction-list-item--inverted');
+});
+
+test('renders with inverted class when isInverted is true', () => {
+  setup({ isInverted: true, level2: 'Beneficiary' });
+
+  const element = document.querySelector('.ods-transaction-list-item');
+  expect(element).toHaveClass('ods-transaction-list-item--inverted');
+});
+
 test('renders default element properly with sub transaction-list-items', () => {
   setup({
     icon: <ExclamationCircle />,

--- a/packages/ocean-react/src/TransactionListItem/stories/TransactionListItem.stories.tsx
+++ b/packages/ocean-react/src/TransactionListItem/stories/TransactionListItem.stories.tsx
@@ -67,6 +67,11 @@ const meta: Meta<typeof TransactionListItem> = {
       description: 'Exibe estado de carregamento.',
       control: 'boolean',
     },
+    isInverted: {
+      description:
+        'Inverte a hierarquia tipográfica entre Level 1 e Level 2.',
+      control: 'boolean',
+    },
     className: {
       description: 'Classes CSS adicionais.',
       control: 'text',
@@ -302,6 +307,33 @@ export const CompleteExample: Story = {
         tags={<Tag>Processando</Tag>}
       >
         Saque em dinheiro
+      </TransactionListItem>
+    </List>
+  ),
+};
+
+export const Inverted: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <List>
+      <TransactionListItem
+        icon={<Reply />}
+        level2="Transferência PIX"
+        value="R$ 250,00"
+        positive
+      >
+        João da Silva
+      </TransactionListItem>
+      <TransactionListItem
+        icon={<Reply />}
+        level2="Transferência PIX"
+        value="R$ 250,00"
+        positive
+        isInverted
+      >
+        João da Silva
       </TransactionListItem>
     </List>
   ),


### PR DESCRIPTION
## Summary
- Add `isInverted` prop to `TransactionListItem` component (default: `false`)
- When `true`, swaps typography sizes between level1 (paragraph → description) and level2 (description → paragraph)
- Adds SCSS modifier class `ods-transaction-list-item--inverted` with font-size overrides
- Adds unit tests for both default and inverted states

## Related
- Issue: Pagnet/mfe-statement#102

## Test plan
- [x] Verify default rendering unchanged (no inverted class)
- [x] Verify `isInverted={true}` adds the modifier class
- [x] Verify visual font-size swap in Storybook
- [x] Confirm no breaking changes to existing consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)