### PR TITLE
fix: swap colors in isInverted mode (BAN-52)

### DIFF
--- a/packages/ocean-core/src/components/_list-item.scss
+++ b/packages/ocean-core/src/components/_list-item.scss
@@ -225,7 +225,7 @@
   }
 
   .ods-transaction-list-item__level2 {
-    color: $color-interface-dark-pure;
+    color: $color-interface-dark-deep;
     font-size: $font-size-xs;
   }
 }

--- a/packages/ocean-core/src/components/_list-item.scss
+++ b/packages/ocean-core/src/components/_list-item.scss
@@ -220,10 +220,12 @@
 
 .ods-transaction-list-item--inverted {
   .ods-transaction-list-item__level1 {
+    color: $color-interface-dark-down;
     font-size: $font-size-xxs;
   }
 
   .ods-transaction-list-item__level2 {
+    color: $color-interface-dark-pure;
     font-size: $font-size-xs;
   }
 }


### PR DESCRIPTION
## Summary
- When `isInverted` is true on `TransactionListItem`, colors now also swap along with font sizes
- **level1**: `$color-interface-dark-pure` → `$color-interface-dark-down` (becomes secondary)
- **level2**: `$color-interface-dark-down` → `$color-interface-dark-pure` (becomes primary)

## Related
- Previous PR: ocean-ds/ocean-web#1236 (merged — added `isInverted` prop)
- Issue: Pagnet/mfe-statement#102

## Test plan
- [x] Verify level1 text becomes gray (`dark-down`) when `isInverted={true}`
- [x] Verify level2 text becomes dark (`dark-pure`) when `isInverted={true}`
- [x] Verify default behavior unchanged when `isInverted={false}` or absent

Refs: BAN-52

🤖 Generated with [Claude Code](https://claude.com/claude-code)