### PR TITLE
feat(list-selectable): add cornerTag prop with Highlight Corner Tag (MR-490)

### DIFF
--- a/packages/ocean-core/src/components/_all.scss
+++ b/packages/ocean-core/src/components/_all.scss
@@ -41,5 +41,6 @@
 @import 'list-settings';
 @import 'list-expandable';
 @import 'list-selectable';
+@import 'corner-tag';
 @import 'internal-contextual-hero';
 @import 'contextual-menu';

--- a/packages/ocean-core/src/components/_corner-tag.scss
+++ b/packages/ocean-core/src/components/_corner-tag.scss
@@ -1,0 +1,25 @@
+.ods-corner-tag {
+  align-items: center;
+  border-radius: 0 0 0 $border-radius-sm;
+  color: $color-interface-light-pure;
+  display: inline-flex;
+  font-family: $font-family-base;
+  font-size: $font-size-xxxs;
+  font-weight: $font-weight-extrabold;
+  height: 20px;
+  justify-content: flex-end;
+  padding: 0 $spacing-inline-xxs;
+  position: absolute;
+  right: 0;
+  text-align: right;
+  top: 0;
+  z-index: 2;
+
+  &--primaryDown {
+    background-color: $color-brand-primary-down;
+  }
+
+  &--complementaryPure {
+    background-color: $color-complementary-pure;
+  }
+}

--- a/packages/ocean-react/src/CornerTag/CornerTag.tsx
+++ b/packages/ocean-react/src/CornerTag/CornerTag.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import classNames from 'classnames';
+
+export type CornerTagColor = 'primaryDown' | 'complementaryPure';
+
+export interface CornerTagProps {
+  /** Text displayed inside the tag. Empty strings render nothing. */
+  label: string;
+  /** Background color variant. Defaults to `primaryDown`. */
+  color?: CornerTagColor;
+  /** Additional class names applied to the root element. */
+  className?: string;
+}
+
+const CornerTag = React.forwardRef<HTMLSpanElement, CornerTagProps>(
+  ({ label, color = 'primaryDown', className }, ref) => {
+    if (!label) return null;
+
+    return (
+      <span
+        ref={ref}
+        className={classNames(
+          'ods-corner-tag',
+          `ods-corner-tag--${color}`,
+          className
+        )}
+        aria-label={label}
+      >
+        {label}
+      </span>
+    );
+  }
+);
+
+CornerTag.displayName = 'CornerTag';
+
+export default CornerTag;

--- a/packages/ocean-react/src/CornerTag/__tests__/CornerTag.test.tsx
+++ b/packages/ocean-react/src/CornerTag/__tests__/CornerTag.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import CornerTag from '../CornerTag';
+
+test('renders with default color (primaryDown)', () => {
+  render(<CornerTag label="Recomendado" />);
+
+  const tag = screen.getByText('Recomendado');
+  expect(tag).toHaveClass('ods-corner-tag');
+  expect(tag).toHaveClass('ods-corner-tag--primaryDown');
+  expect(tag).toHaveAttribute('aria-label', 'Recomendado');
+});
+
+test('renders with complementaryPure color', () => {
+  render(<CornerTag label="Novo" color="complementaryPure" />);
+
+  const tag = screen.getByText('Novo');
+  expect(tag).toHaveClass('ods-corner-tag--complementaryPure');
+});
+
+test('does not render when label is empty', () => {
+  const { container } = render(<CornerTag label="" />);
+
+  expect(container).toBeEmptyDOMElement();
+});
+
+test('forwards additional class names', () => {
+  render(<CornerTag label="Promo" className="custom-class" />);
+
+  expect(screen.getByText('Promo')).toHaveClass('custom-class');
+});
+
+test('expands without truncation for long labels', () => {
+  const longLabel = 'Texto muito longo que pode quebrar a linha';
+  render(<CornerTag label={longLabel} />);
+
+  const tag = screen.getByText(longLabel);
+  expect(tag).toHaveTextContent(longLabel);
+  expect(tag).toHaveAttribute('aria-label', longLabel);
+});

--- a/packages/ocean-react/src/CornerTag/index.ts
+++ b/packages/ocean-react/src/CornerTag/index.ts
@@ -1,0 +1,2 @@
+export { default } from './CornerTag';
+export type { CornerTagProps, CornerTagColor } from './CornerTag';

--- a/packages/ocean-react/src/ListReadOnly/ListReadOnly.tsx
+++ b/packages/ocean-react/src/ListReadOnly/ListReadOnly.tsx
@@ -7,6 +7,7 @@ import SkeletonBar from '../_shared/components/SkeletonBar';
 import ListContainer, {
   ListContainerHighlight,
 } from '../_shared/components/ListContainer';
+import { CornerTagProps } from '../CornerTag/CornerTag';
 
 export type ListReadOnlyProps = {
   /**
@@ -67,6 +68,11 @@ export type ListReadOnlyProps = {
    * Renders a highlighted caption area at the bottom of the container.
    */
   highlight?: ListContainerHighlight;
+  /**
+   * Renders a Highlight Corner Tag at the top-right corner of the card.
+   * Only rendered when `type='card'`.
+   */
+  cornerTag?: CornerTagProps;
 } & React.ComponentPropsWithoutRef<'div'>;
 
 const ListReadOnly = React.forwardRef<HTMLDivElement, ListReadOnlyProps>(
@@ -86,6 +92,7 @@ const ListReadOnly = React.forwardRef<HTMLDivElement, ListReadOnlyProps>(
       className,
       showDivider = false,
       highlight,
+      cornerTag,
       ...rest
     },
     ref
@@ -135,6 +142,7 @@ const ListReadOnly = React.forwardRef<HTMLDivElement, ListReadOnlyProps>(
         type={type}
         showDivider={showDivider}
         highlight={highlight}
+        cornerTag={cornerTag}
       >
         <div
           ref={ref}

--- a/packages/ocean-react/src/ListSelectable/ListSelectable.tsx
+++ b/packages/ocean-react/src/ListSelectable/ListSelectable.tsx
@@ -10,8 +10,9 @@ import ListReadOnly from '../ListReadOnly/ListReadOnly';
 import ListContainer, {
   ListContainerHighlight,
 } from '../_shared/components/ListContainer';
+import { CornerTagProps } from '../CornerTag/CornerTag';
 
-interface ListSelectableProps {
+interface ListSelectableBaseProps {
   /** Required main title displayed on the list item. */
   title: string;
   /** Optional secondary text rendered below the title. */
@@ -38,8 +39,6 @@ interface ListSelectableProps {
   indicator?: ReactNode;
   /** Visual state applied to the text content (`default`, `warning`, etc.). */
   status?: ContentListProps['type'];
-  /** Layout style of the wrapper: `text` keeps inline divider, `card` shows borders. */
-  type?: 'card' | 'text';
   /** Platform context used to adjust spacing (web or app). */
   platform?: 'web' | 'app';
   /** If the selectable is disabled, the input will be hidden and the content will be rendered as ListReadOnly. */
@@ -48,9 +47,27 @@ interface ListSelectableProps {
   highlight?: ListContainerHighlight;
 }
 
+type ListSelectableCardProps = ListSelectableBaseProps & {
+  /** Layout style of the wrapper: `text` keeps inline divider, `card` shows borders. */
+  type?: 'card';
+  /**
+   * Renders a Highlight Corner Tag at the top-right corner of the card.
+   * Only available when `type='card'`.
+   */
+  cornerTag?: CornerTagProps;
+};
+
+type ListSelectableTextProps = ListSelectableBaseProps & {
+  type: 'text';
+  /** Corner Tag is not supported in `type='text'` (no visual container to anchor it). */
+  cornerTag?: never;
+};
+
+type ListSelectableProps = ListSelectableCardProps | ListSelectableTextProps;
+
 const ListSelectable = React.forwardRef<HTMLDivElement, ListSelectableProps>(
-  (
-    {
+  (props, ref) => {
+    const {
       title,
       description,
       caption,
@@ -68,10 +85,10 @@ const ListSelectable = React.forwardRef<HTMLDivElement, ListSelectableProps>(
       status = 'default',
       type = 'card',
       platform = 'web',
+      cornerTag: _cornerTag,
       ...rest
-    },
-    ref
-  ) => {
+    } = props as ListSelectableCardProps;
+    const cornerTag = type === 'card' ? _cornerTag : undefined;
     const hasError = useMemo(
       () => radio?.error || checkbox?.error,
       [radio?.error, checkbox?.error]
@@ -141,6 +158,7 @@ const ListSelectable = React.forwardRef<HTMLDivElement, ListSelectableProps>(
           caption={caption}
           strikethroughDescription={strikethroughDescription}
           highlight={highlight}
+          cornerTag={cornerTag}
           {...rest}
           ref={ref}
         />
@@ -153,6 +171,7 @@ const ListSelectable = React.forwardRef<HTMLDivElement, ListSelectableProps>(
         showDivider={showDivider}
         hasError={hasError}
         highlight={highlight}
+        cornerTag={cornerTag}
       >
         <div
           className={classNames('ods-list-selectable', className, {

--- a/packages/ocean-react/src/ListSelectable/__tests__/ListSelectable.test.tsx
+++ b/packages/ocean-react/src/ListSelectable/__tests__/ListSelectable.test.tsx
@@ -1,0 +1,234 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import ListSelectable from '../ListSelectable';
+
+describe('ListSelectable — basic rendering', () => {
+  test('renders title and description with checkbox', () => {
+    render(
+      <ListSelectable
+        title="Title"
+        description="Description"
+        checkbox={{ id: 'cb-1' }}
+      />
+    );
+
+    expect(screen.getByText('Title')).toBeInTheDocument();
+    expect(screen.getByText('Description')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+  });
+
+  test('renders with radio controller', () => {
+    render(
+      <ListSelectable
+        title="Title"
+        radio={{ id: 'r-1', name: 'group' }}
+      />
+    );
+
+    expect(screen.getByRole('radio')).toBeInTheDocument();
+  });
+
+  test('shows skeleton when loading (title is hidden)', () => {
+    render(
+      <ListSelectable
+        title="Title"
+        loading
+        checkbox={{ id: 'cb-loading' }}
+      />
+    );
+
+    expect(screen.queryByText('Title')).not.toBeInTheDocument();
+  });
+
+  test('renders inline indicator (existing tag inline)', () => {
+    render(
+      <ListSelectable
+        title="Title"
+        indicator={<span data-testid="indicator">Inline</span>}
+        checkbox={{ id: 'cb-ind' }}
+      />
+    );
+
+    expect(screen.getByTestId('indicator')).toBeInTheDocument();
+  });
+});
+
+describe('ListSelectable — cornerTag (V-02 to V-14)', () => {
+  test('V-02: renders Corner Tag in card type with default color', () => {
+    render(
+      <ListSelectable
+        title="Title"
+        checkbox={{ id: 'cb-corner' }}
+        cornerTag={{ label: 'Recomendado' }}
+      />
+    );
+
+    const tag = screen.getByText('Recomendado');
+    expect(tag).toHaveClass('ods-corner-tag');
+    expect(tag).toHaveClass('ods-corner-tag--primaryDown');
+    expect(tag).toHaveAttribute('aria-label', 'Recomendado');
+  });
+
+  test('V-03: renders both inline indicator and Corner Tag simultaneously', () => {
+    render(
+      <ListSelectable
+        title="Title"
+        indicator={<span data-testid="inline-tag">Inline</span>}
+        checkbox={{ id: 'cb-both' }}
+        cornerTag={{ label: 'Corner' }}
+      />
+    );
+
+    expect(screen.getByTestId('inline-tag')).toBeInTheDocument();
+    expect(screen.getByText('Corner')).toBeInTheDocument();
+  });
+
+  test('V-04: renders without any tag when neither is provided', () => {
+    render(<ListSelectable title="Title" checkbox={{ id: 'cb-none' }} />);
+
+    expect(screen.queryByText('Recomendado')).not.toBeInTheDocument();
+  });
+
+  test('V-05: does NOT render Corner Tag when type=text', () => {
+    render(
+      <ListSelectable
+        type="text"
+        title="Title"
+        checkbox={{ id: 'cb-text' }}
+      />
+    );
+
+    expect(screen.queryByText('Recomendado')).not.toBeInTheDocument();
+  });
+
+  test('V-06: Corner Tag persists in selected state', () => {
+    render(
+      <ListSelectable
+        title="Title"
+        checkbox={{ id: 'cb-selected', checked: true }}
+        cornerTag={{ label: 'Selected' }}
+      />
+    );
+
+    expect(screen.getByText('Selected')).toBeInTheDocument();
+  });
+
+  test('V-07: Corner Tag keeps normal appearance in disabled state', () => {
+    render(
+      <ListSelectable
+        title="Title"
+        disabled
+        checkbox={{ id: 'cb-disabled', disabled: true }}
+        cornerTag={{ label: 'Disabled' }}
+      />
+    );
+
+    const tag = screen.getByText('Disabled');
+    expect(tag).toHaveClass('ods-corner-tag--primaryDown');
+    expect(tag).not.toHaveClass('ods-corner-tag--disabled');
+  });
+
+  test('V-08: Corner Tag is hidden during loading', () => {
+    render(
+      <ListSelectable
+        title="Title"
+        loading
+        checkbox={{ id: 'cb-loading-corner' }}
+        cornerTag={{ label: 'Hidden' }}
+      />
+    );
+
+    expect(screen.queryByText('Hidden')).not.toBeInTheDocument();
+  });
+
+  test('V-09: Corner Tag persists when card has error', () => {
+    render(
+      <ListSelectable
+        title="Title"
+        checkbox={{ id: 'cb-error', error: true }}
+        cornerTag={{ label: 'WithError' }}
+      />
+    );
+
+    expect(screen.getByText('WithError')).toBeInTheDocument();
+  });
+
+  test('V-10: empty label does not render Corner Tag', () => {
+    render(
+      <ListSelectable
+        title="Title"
+        checkbox={{ id: 'cb-empty' }}
+        cornerTag={{ label: '' }}
+      />
+    );
+
+    // No aria-label="" element is expected; querying any text 'Recomendado' is a stand-in check.
+    expect(screen.queryByLabelText('')).not.toBeInTheDocument();
+  });
+
+  test('V-11: long label renders without truncation', () => {
+    const longLabel = 'Texto muito longo que pode quebrar a linha';
+    render(
+      <ListSelectable
+        title="Title"
+        checkbox={{ id: 'cb-long' }}
+        cornerTag={{ label: longLabel }}
+      />
+    );
+
+    expect(screen.getByText(longLabel)).toHaveTextContent(longLabel);
+  });
+
+  test('V-12: Corner Tag works with checkbox', () => {
+    render(
+      <ListSelectable
+        title="Title"
+        checkbox={{ id: 'cb-corner' }}
+        cornerTag={{ label: 'Checkbox' }}
+      />
+    );
+
+    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+    expect(screen.getByText('Checkbox')).toBeInTheDocument();
+  });
+
+  test('V-13: Corner Tag works with radio', () => {
+    render(
+      <ListSelectable
+        title="Title"
+        radio={{ id: 'r-corner', name: 'g' }}
+        cornerTag={{ label: 'Radio' }}
+      />
+    );
+
+    expect(screen.getByRole('radio')).toBeInTheDocument();
+    expect(screen.getByText('Radio')).toBeInTheDocument();
+  });
+
+  test('V-14: complementaryPure color renders correct class', () => {
+    render(
+      <ListSelectable
+        title="Title"
+        checkbox={{ id: 'cb-comp' }}
+        cornerTag={{ label: 'Novo', color: 'complementaryPure' }}
+      />
+    );
+
+    expect(screen.getByText('Novo')).toHaveClass(
+      'ods-corner-tag--complementaryPure'
+    );
+  });
+
+  test('Corner Tag is forwarded to ListReadOnly when isSelectableDisabled', () => {
+    render(
+      <ListSelectable
+        title="Title"
+        isSelectableDisabled
+        cornerTag={{ label: 'ReadOnly' }}
+      />
+    );
+
+    expect(screen.getByText('ReadOnly')).toBeInTheDocument();
+  });
+});

--- a/packages/ocean-react/src/ListSelectable/stories/ListSelectable.stories.tsx
+++ b/packages/ocean-react/src/ListSelectable/stories/ListSelectable.stories.tsx
@@ -658,6 +658,57 @@ export const SelectableDisabled: Story = {
   ),
 };
 
+// Story: Com Corner Tag
+export const WithCornerTag: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <div style={storyStyles.container}>
+      <ListSelectable
+        title="Plano Premium"
+        description="R$ 49,90/mês"
+        checkbox={{ id: 'corner-tag-1' }}
+        cornerTag={{ label: 'Recomendado' }}
+      />
+      <ListSelectable
+        title="Plano Plus"
+        description="R$ 79,90/mês"
+        radio={{ id: 'corner-tag-2', name: 'plan' }}
+        cornerTag={{ label: 'Novo', color: 'complementaryPure' }}
+      />
+      <ListSelectable
+        title="Plano com inline e corner"
+        description="Coexistência das duas tags"
+        checkbox={{ id: 'corner-tag-3' }}
+        indicator={
+          <Tag type="positive" size="small" setIconOff>
+            Aprovado
+          </Tag>
+        }
+        cornerTag={{ label: 'Mais vendido' }}
+      />
+      <ListSelectable
+        title="Plano selecionado"
+        description="Corner Tag persiste em selected"
+        checkbox={{ id: 'corner-tag-4', checked: true }}
+        cornerTag={{ label: 'Em breve', color: 'complementaryPure' }}
+      />
+      <ListSelectable
+        title="Plano desabilitado"
+        description="Corner Tag mantém aparência normal"
+        disabled
+        checkbox={{ id: 'corner-tag-5', disabled: true }}
+        cornerTag={{ label: 'Recomendado' }}
+      />
+      <ListSelectable
+        title="Plano com label longo"
+        description="Corner Tag expande sem truncamento"
+        checkbox={{ id: 'corner-tag-6' }}
+        cornerTag={{ label: 'Texto muito longo de exemplo' }}
+      />
+    </div>
+  ),
+};
+
 // Story: Com Highlight
 export const WithHighlight: Story = {
   parameters: { controls: { disable: true } },

--- a/packages/ocean-react/src/_shared/components/ListContainer/ListContainer.tsx
+++ b/packages/ocean-react/src/_shared/components/ListContainer/ListContainer.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react';
 import classNames from 'classnames';
+import CornerTag, { CornerTagProps } from '../../../CornerTag/CornerTag';
 
 export type ListContainerHighlight = {
   /**
@@ -36,6 +37,11 @@ export type ListContainerProps = {
    * Renders a highlighted caption area at the bottom of the container.
    */
   highlight?: ListContainerHighlight;
+  /**
+   * Renders a Highlight Corner Tag at the top-right corner of the card.
+   * Only rendered when `type='card'` (no visual container in `type='text'`).
+   */
+  cornerTag?: CornerTagProps;
   children: ReactNode;
   className?: string;
 } & React.ComponentPropsWithoutRef<'div'>;
@@ -47,6 +53,7 @@ const ListContainer = React.forwardRef<HTMLDivElement, ListContainerProps>(
       showDivider = false,
       hasError = false,
       highlight,
+      cornerTag,
       children,
       className,
       ...rest
@@ -68,6 +75,7 @@ const ListContainer = React.forwardRef<HTMLDivElement, ListContainerProps>(
         {showDivider && type === 'text' && (
           <div className="ods-list-container__content__divider" />
         )}
+        {type === 'card' && cornerTag?.label && <CornerTag {...cornerTag} />}
       </div>
       {highlight?.caption && (
         <div


### PR DESCRIPTION
> Re-open of #1240 targeting `master`. Original author: @igor-monteiro-almeida.

## Summary

Adds support for the **Highlight Corner Tag** in `ListSelectable` (and `ListReadOnly` via `isSelectableDisabled`). The new `CornerTag` lives as an internal subcomponent under `src/CornerTag/` (not exported publicly in this release) and is rendered as an overlay at the top-right corner of card containers.

- New `CornerTag` component with `primaryDown` / `complementaryPure` colors (tokens: `$color-brand-primary-down` / `$color-complementary-pure`)
- `ListSelectable` receives a new `cornerTag` prop via discriminated union: only allowed when `type='card'`; `type='text'` sets `cornerTag?: never` to block at compile-time (per spec OQ-S6 — no runtime warns)
- `ListContainer` renders `CornerTag` conditionally for `type='card'` (single source of truth)
- `ListReadOnly` accepts and forwards `cornerTag` (covers `isSelectableDisabled` flow)
- Stories cover all V-02..V-14 variants from the spec
- Unit tests cover `CornerTag` standalone + 16 `ListSelectable` variants
- 722 tests passing in full ocean-react suite — zero regressions

### Spec & PRD
- PRD: https://github.com/Pagnet/pagnet/issues/16178
- Technical spec (with all OpenQuestions resolved): https://github.com/Pagnet/pagnet/issues/16178#issuecomment-4343595459
- Jira: [MR-490](https://useblu.atlassian.net/browse/MR-490)

### API contract

```tsx
<ListSelectable
  type="card"
  title="Plano Premium"
  description="R$ 49,90/mês"
  checkbox={{ id: 'plan-1' }}
  cornerTag={{ label: 'Recomendado' }}                       // primaryDown (default)
/>

<ListSelectable
  type="card"
  title="Plano Plus"
  radio={{ id: 'plan-2', name: 'plan' }}
  cornerTag={{ label: 'Novo', color: 'complementaryPure' }}
/>
```

`type='text'` + `cornerTag` is blocked by TypeScript (discriminated union).

## Test plan

- [x] `yarn lint` — zero errors on changed files
- [x] `yarn jest` (ocean-react) — 722/722 passing, 64 suites, zero regressions
- [x] CornerTag unit tests — primaryDown/complementaryPure colors, empty label, long label, custom className
- [x] ListSelectable unit tests — V-02..V-14 variants (only inline / only corner / both / none / type=text / disabled / loading / selected / error / checkbox / radio / complementaryPure / forwarded to ListReadOnly when isSelectableDisabled)
- [ ] Visual regression (Storybook snapshots) — to be checked by reviewer
- [ ] A11y review — span + `aria-label`, no `role="status"`, reading order after card content

## Decisions resolved during the spec
- `cornerTag` is a discriminated-union prop — `type='text'` blocks usage at compile-time
- `CornerTag` is internal-only (not exported in `src/index.ts` this release; future export is a follow-up when consumers like `CardGroup` need it)
- Tokens reused from existing scss: `$color-brand-primary-down`, `$color-complementary-pure`, `$font-family-base`, `$font-weight-extrabold`, `$font-size-xxxs`
- `ListContainer` (shared) is the single source of truth — `ListSelectable` and `ListReadOnly` both inherit support automatically
