### PR TITLE
fix(list-container): card border color should match Figma spec

### DIFF
--- a/packages/ocean-core/src/components/_list-container.scss
+++ b/packages/ocean-core/src/components/_list-container.scss
@@ -8,7 +8,7 @@
   }
 
   &__content--card {
-    border: $border-width-hairline solid $color-interface-light-deep;
+    border: $border-width-hairline solid $color-interface-light-down;
     border-radius: $border-radius-sm;
 
     &--error {


### PR DESCRIPTION
## Summary

The card variant of `ListContainer` currently uses `$color-interface-light-deep` (`#CED1E1`) for its border. The Figma spec for list cards specifies `$color-interface-light-down` (`#E0E2EE`), which is one step lighter. Switching the token aligns the implementation with the design source of truth across **all** card-style list components.

```diff
- border: $border-width-hairline solid $color-interface-light-deep;
+ border: $border-width-hairline solid $color-interface-light-down;
```

## Affected components

`ListContainer` is shared, so this change visually affects **every** card-style consumer:

- `ListSelectable` (`type='card'`)
- `ListReadOnly` (`type='card'`)
- `ListAction`, `ListExpandable`, `ListSettings` and any future component that wraps `ListContainer` with `type='card'`

The change is **only the border color** — width, radius, padding and content layout are unchanged.

## Token values

| Token | Hex | Note |
|---|---|---|
| `$color-interface-light-deep` (current) | `#CED1E1` | rgb(206, 209, 225) — darker |
| `$color-interface-light-down` (Figma) | `#E0E2EE` | rgb(224, 226, 238) — lighter ✅ |

## Test plan

- [x] `yarn jest` (ocean-react) — all suites passing, no regressions caused by this change
- [ ] Visual regression (Storybook / Chromatic) — reviewer should compare card border before/after across all list components
- [ ] Cross-check with Figma source: list cards in `ListSelectable`, `ListReadOnly`, `ListAction`

## Context

Found while implementing the Highlight Corner Tag in `ListSelectable` (#1240). The divergence is **pre-existing** and not caused by that PR — opening this as a separate fix to keep concerns isolated and make the visual change reviewable in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
