### PR TITLE
feat: add Banner component

### DIFF
--- a/packages/ocean-core/src/components/_all.scss
+++ b/packages/ocean-core/src/components/_all.scss
@@ -1,4 +1,5 @@
 @import 'alert';
+@import 'banner';
 @import 'badge';
 @import 'button';
 @import 'carousel';

--- a/packages/ocean-core/src/components/_banner.scss
+++ b/packages/ocean-core/src/components/_banner.scss
@@ -61,6 +61,10 @@
       flex-shrink: 0;
       width: 25%;
 
+      @include media-breakpoint-down(md) {
+        width: 100%;
+      }
+
       .ods-banner__image {
         display: block;
         height: 100%;
@@ -131,21 +135,7 @@
   &--small {
     .ods-banner__body {
       flex-direction: row;
-    }
-
-    @include media-breakpoint-down(md) {
-      .ods-banner__body {
-        flex-direction: column;
-      }
-
-      .ods-banner__image-wrapper--side {
-        width: 100%;
-
-        .ods-banner__image {
-          height: auto;
-          max-height: 160px;
-        }
-      }
+      flex-wrap: wrap;
     }
   }
 }

--- a/packages/ocean-core/src/components/_banner.scss
+++ b/packages/ocean-core/src/components/_banner.scss
@@ -21,6 +21,10 @@
   &--emphasys {
     background-color: $color-brand-primary-pure;
 
+    .ods-banner__actions .ods-btn--tertiary {
+      color: $color-interface-light-pure;
+    }
+
     .ods-banner__description .ods-typography--inverse {
       color: $color-interface-light-up;
     }
@@ -88,10 +92,6 @@
   // ── Size: large ───────────────────────────────────────────────────────────
 
   &--large {
-    .ods-banner__actions {
-      margin-top: $spacing-stack-sm;
-    }
-
     .ods-banner__body {
       flex-direction: column;
     }

--- a/packages/ocean-core/src/components/_banner.scss
+++ b/packages/ocean-core/src/components/_banner.scss
@@ -84,6 +84,7 @@
   // ── Description ───────────────────────────────────────────────────────────
 
   &__description {
+    font-weight: $font-weight-medium;
     margin-top: $spacing-stack-xxxs;
   }
 

--- a/packages/ocean-core/src/components/_banner.scss
+++ b/packages/ocean-core/src/components/_banner.scss
@@ -84,6 +84,10 @@
 
   // ── Actions ───────────────────────────────────────────────────────────────
 
+  .ods-btn--sm {
+    min-width: unset;
+  }
+
   &__actions {
     display: flex;
     flex-wrap: wrap;

--- a/packages/ocean-core/src/components/_banner.scss
+++ b/packages/ocean-core/src/components/_banner.scss
@@ -1,5 +1,5 @@
 .ods-banner {
-  border-radius: $border-radius-md;
+  border-radius: $border-radius-sm;
   font-family: $font-family-base;
   overflow: hidden;
   width: 100%;
@@ -8,37 +8,21 @@
 
   &--default {
     background-color: $color-interface-light-up;
-
-    .ods-banner__title,
-    .ods-banner__description {
-      color: $color-interface-dark-deep;
-    }
   }
 
   &--warning {
     background-color: $color-status-warning-up;
-
-    .ods-banner__title,
-    .ods-banner__description {
-      color: $color-interface-dark-deep;
-    }
   }
 
   &--negative {
     background-color: $color-status-negative-up;
-
-    .ods-banner__title,
-    .ods-banner__description {
-      color: $color-interface-dark-deep;
-    }
   }
 
   &--emphasys {
     background-color: $color-brand-primary-pure;
 
-    .ods-banner__title,
-    .ods-banner__description {
-      color: $color-interface-light-pure;
+    .ods-banner__description .ods-typography--inverse {
+      color: $color-interface-light-up;
     }
   }
 
@@ -58,7 +42,7 @@
 
   &__image-wrapper--side {
     flex-shrink: 0;
-    width: 25%;
+    width: 82px;
 
     @include media-breakpoint-down(md) {
       width: 100%;
@@ -83,32 +67,13 @@
     display: flex;
     flex: 1;
     flex-direction: column;
-    gap: $spacing-stack-xxs;
     padding: $spacing-inset-sm;
-  }
-
-  // ── Title ─────────────────────────────────────────────────────────────────
-
-  &__title {
-    font-size: $font-size-sm;
-    font-weight: $font-weight-extrabold;
-    line-height: $line-height-medium;
-
-    @include media-breakpoint-down(md) {
-      font-size: $font-size-xs;
-    }
   }
 
   // ── Description ───────────────────────────────────────────────────────────
 
   &__description {
-    font-size: $font-size-xxs;
-    font-weight: $font-weight-regular;
-    line-height: $line-height-comfy;
-
-    @include media-breakpoint-down(md) {
-      font-size: $font-size-xxxs;
-    }
+    margin-top: $spacing-stack-xxxs;
   }
 
   // ── Actions ───────────────────────────────────────────────────────────────
@@ -117,12 +82,16 @@
     display: flex;
     flex-wrap: wrap;
     gap: $spacing-inline-xs;
-    margin-top: $spacing-stack-xxxs;
+    margin-top: $spacing-stack-xxs-extra;
   }
 
   // ── Size: large ───────────────────────────────────────────────────────────
 
   &--large {
+    .ods-banner__actions {
+      margin-top: $spacing-stack-sm;
+    }
+
     .ods-banner__body {
       flex-direction: column;
     }

--- a/packages/ocean-core/src/components/_banner.scss
+++ b/packages/ocean-core/src/components/_banner.scss
@@ -42,43 +42,41 @@
     }
   }
 
-  // ── Image ─────────────────────────────────────────────────────────────────
+  // ── Image wrappers (flattened to depth 1 to respect max-nesting-depth) ───
 
-  &__image-wrapper {
-    &--top {
+  &__image-wrapper--top {
+    line-height: 0;
+    width: 100%;
+  }
+
+  &__image-wrapper--top &__image {
+    display: block;
+    height: auto;
+    object-fit: cover;
+    width: 100%;
+  }
+
+  &__image-wrapper--side {
+    flex-shrink: 0;
+    width: 25%;
+
+    @include media-breakpoint-down(md) {
       width: 100%;
-      line-height: 0;
-
-      .ods-banner__image {
-        display: block;
-        height: auto;
-        object-fit: cover;
-        width: 100%;
-      }
     }
+  }
 
-    &--side {
-      flex-shrink: 0;
-      width: 25%;
-
-      @include media-breakpoint-down(md) {
-        width: 100%;
-      }
-
-      .ods-banner__image {
-        display: block;
-        height: 100%;
-        object-fit: cover;
-        width: 100%;
-      }
-    }
+  &__image-wrapper--side &__image {
+    display: block;
+    height: 100%;
+    object-fit: cover;
+    width: 100%;
   }
 
   // ── Body ──────────────────────────────────────────────────────────────────
 
   &__body {
-    display: flex;
     align-items: stretch;
+    display: flex;
   }
 
   &__content {

--- a/packages/ocean-core/src/components/_banner.scss
+++ b/packages/ocean-core/src/components/_banner.scss
@@ -103,6 +103,10 @@
     .ods-banner__body {
       flex-direction: column;
     }
+
+    .ods-banner__actions {
+      margin-top: $spacing-stack-sm;
+    }
   }
 
   // ── Size: small ───────────────────────────────────────────────────────────

--- a/packages/ocean-core/src/components/_banner.scss
+++ b/packages/ocean-core/src/components/_banner.scss
@@ -47,10 +47,6 @@
   &__image-wrapper--side {
     flex-shrink: 0;
     width: 82px;
-
-    @include media-breakpoint-down(md) {
-      width: 100%;
-    }
   }
 
   &__image-wrapper--side &__image {
@@ -114,7 +110,7 @@
   &--small {
     .ods-banner__body {
       flex-direction: row;
-      flex-wrap: wrap;
+      flex-wrap: nowrap;
     }
   }
 }

--- a/packages/ocean-core/src/components/_banner.scss
+++ b/packages/ocean-core/src/components/_banner.scss
@@ -70,16 +70,14 @@
     padding: $spacing-inset-sm;
   }
 
-  // ── Title ─────────────────────────────────────────────────────────────────
+  // ── Typography overrides ──────────────────────────────────────────────────
 
-  &__title {
+  .ods-typography__heading4 {
     font-weight: $font-weight-bold;
     line-height: $line-height-medium;
   }
 
-  // ── Description ───────────────────────────────────────────────────────────
-
-  &__description {
+  .ods-typography__description {
     font-weight: $font-weight-medium;
     margin-top: $spacing-stack-xxxs;
   }

--- a/packages/ocean-core/src/components/_banner.scss
+++ b/packages/ocean-core/src/components/_banner.scss
@@ -1,0 +1,151 @@
+.ods-banner {
+  border-radius: $border-radius-md;
+  font-family: $font-family-base;
+  overflow: hidden;
+  width: 100%;
+
+  // ── Type modifiers ────────────────────────────────────────────────────────
+
+  &--default {
+    background-color: $color-interface-light-up;
+
+    .ods-banner__title,
+    .ods-banner__description {
+      color: $color-interface-dark-deep;
+    }
+  }
+
+  &--warning {
+    background-color: $color-status-warning-up;
+
+    .ods-banner__title,
+    .ods-banner__description {
+      color: $color-interface-dark-deep;
+    }
+  }
+
+  &--negative {
+    background-color: $color-status-negative-up;
+
+    .ods-banner__title,
+    .ods-banner__description {
+      color: $color-interface-dark-deep;
+    }
+  }
+
+  &--emphasys {
+    background-color: $color-brand-primary-pure;
+
+    .ods-banner__title,
+    .ods-banner__description {
+      color: $color-interface-light-pure;
+    }
+  }
+
+  // ── Image ─────────────────────────────────────────────────────────────────
+
+  &__image-wrapper {
+    &--top {
+      width: 100%;
+      line-height: 0;
+
+      .ods-banner__image {
+        display: block;
+        height: auto;
+        object-fit: cover;
+        width: 100%;
+      }
+    }
+
+    &--side {
+      flex-shrink: 0;
+      width: 25%;
+
+      .ods-banner__image {
+        display: block;
+        height: 100%;
+        object-fit: cover;
+        width: 100%;
+      }
+    }
+  }
+
+  // ── Body ──────────────────────────────────────────────────────────────────
+
+  &__body {
+    display: flex;
+    align-items: stretch;
+  }
+
+  &__content {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: $spacing-stack-xxs;
+    padding: $spacing-inset-sm;
+  }
+
+  // ── Title ─────────────────────────────────────────────────────────────────
+
+  &__title {
+    font-size: $font-size-sm;
+    font-weight: $font-weight-extrabold;
+    line-height: $line-height-medium;
+
+    @include media-breakpoint-down(md) {
+      font-size: $font-size-xs;
+    }
+  }
+
+  // ── Description ───────────────────────────────────────────────────────────
+
+  &__description {
+    font-size: $font-size-xxs;
+    font-weight: $font-weight-regular;
+    line-height: $line-height-comfy;
+
+    @include media-breakpoint-down(md) {
+      font-size: $font-size-xxxs;
+    }
+  }
+
+  // ── Actions ───────────────────────────────────────────────────────────────
+
+  &__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $spacing-inline-xs;
+    margin-top: $spacing-stack-xxxs;
+  }
+
+  // ── Size: large ───────────────────────────────────────────────────────────
+
+  &--large {
+    .ods-banner__body {
+      flex-direction: column;
+    }
+  }
+
+  // ── Size: small ───────────────────────────────────────────────────────────
+
+  &--small {
+    .ods-banner__body {
+      flex-direction: row;
+    }
+
+    @include media-breakpoint-down(md) {
+      .ods-banner__body {
+        flex-direction: column;
+      }
+
+      .ods-banner__image-wrapper--side {
+        width: 100%;
+
+        .ods-banner__image {
+          height: auto;
+          max-height: 160px;
+        }
+      }
+    }
+  }
+}

--- a/packages/ocean-core/src/components/_banner.scss
+++ b/packages/ocean-core/src/components/_banner.scss
@@ -74,6 +74,13 @@
     padding: $spacing-inset-sm;
   }
 
+  // ── Title ─────────────────────────────────────────────────────────────────
+
+  &__title {
+    font-weight: $font-weight-bold;
+    line-height: $line-height-medium;
+  }
+
   // ── Description ───────────────────────────────────────────────────────────
 
   &__description {

--- a/packages/ocean-core/src/components/_banner.scss
+++ b/packages/ocean-core/src/components/_banner.scss
@@ -25,7 +25,7 @@
       color: $color-interface-light-pure;
     }
 
-    .ods-banner__description .ods-typography--inverse {
+    .ods-typography__description {
       color: $color-interface-light-up;
     }
   }

--- a/packages/ocean-docs/docs/components/banner.mdx
+++ b/packages/ocean-docs/docs/components/banner.mdx
@@ -24,7 +24,7 @@ import Banner from '@useblu/ocean-react/Banner';
 ### Importação de tipos TypeScript
 
 ```tsx
-import type { BannerProps } from '@useblu/ocean-react';
+import type { BannerProps, ActionProps } from '@useblu/ocean-react';
 ```
 
 ## Playground Interativo
@@ -45,10 +45,9 @@ Para documentação técnica detalhada, exemplos de uso e API completa, consulte
 
 ```tsx live
 <Banner
-  size="large"
   title="Título do Banner"
   description="Mensagem descritiva do banner."
-  buttons={[{ label: 'Saiba Mais', onClick: () => console.log('clicked') }]}
+  primaryAction={{ label: 'Saiba Mais', onClick: () => console.log('clicked') }}
 />
 ```
 
@@ -58,8 +57,8 @@ Para documentação técnica detalhada, exemplos de uso e API completa, consulte
 
 O `size` define o layout do banner:
 
-- **`large`** — a imagem ocupa a largura total acima do conteúdo.
-- **`small`** — a imagem fica à direita (25% da largura) e o conteúdo à esquerda.
+- **`large`** *(padrão)* — a imagem ocupa a largura total acima do conteúdo.
+- **`small`** — a imagem fica à direita (82px) e o conteúdo à esquerda.
 
 ```tsx live
 <Banner
@@ -67,7 +66,7 @@ O `size` define o layout do banner:
   title="Banner Large"
   description="Imagem no topo, conteúdo abaixo."
   image="https://placehold.co/800x200"
-  buttons={[{ label: 'Ação', onClick: () => {} }]}
+  primaryAction={{ label: 'Ação', onClick: () => {} }}
 />
 ```
 
@@ -77,26 +76,42 @@ O `size` define o layout do banner:
   title="Banner Small"
   description="Imagem à direita, conteúdo à esquerda."
   image="https://placehold.co/200x150"
-  buttons={[{ label: 'Ação', onClick: () => {} }]}
+  primaryAction={{ label: 'Ação', onClick: () => {} }}
 />
 ```
 
 ### Tipos (type)
 
-| Tipo        | Cor de fundo                   | Cor do texto                |
-| ----------- | ------------------------------ | --------------------------- |
-| `default`   | `$color-interface-light-up`    | `$color-interface-dark-deep` |
-| `warning`   | `$color-status-warning-up`     | `$color-interface-dark-deep` |
-| `negative`  | `$color-status-negative-up`    | `$color-interface-dark-deep` |
-| `emphasys`  | `$color-brand-primary-pure`    | `$color-interface-light-pure` |
+| Tipo        | Cor de fundo                   | Título                        | Descrição                     |
+| ----------- | ------------------------------ | ----------------------------- | ----------------------------- |
+| `default`   | `$color-interface-light-up`    | `$color-interface-dark-deep`  | `$color-interface-dark-down`  |
+| `warning`   | `$color-status-warning-up`     | `$color-interface-dark-deep`  | `$color-interface-dark-down`  |
+| `negative`  | `$color-status-negative-up`    | `$color-interface-dark-deep`  | `$color-interface-dark-down`  |
+| `emphasys`  | `$color-brand-primary-pure`    | `$color-interface-light-pure` | `$color-interface-light-up`   |
 
-Para o tipo `emphasys`, os botões usam a variante `inverse`.
+### Variantes de botão por tipo
+
+A variante dos botões é derivada automaticamente do `type` — não é necessário especificá-la manualmente.
+
+| Tipo       | `primaryAction`   | `secondaryAction`  |
+| ---------- | ----------------- | ------------------ |
+| `default`  | `primary`         | `tertiary`         |
+| `warning`  | `primaryWarning`  | `tertiaryWarning`  |
+| `negative` | `primaryCritical` | `tertiaryCritical` |
+| `emphasys` | `secondary`       | `tertiary` (texto `$color-interface-light-pure`) |
 
 <StorybookEmbed
-  storyId="components-banner--types"
+  storyId="components-banner--with-primary-and-secondary-actions"
   height={700}
   showToolbar={false}
-  title="Banner - Tipos"
+  title="Banner - Primária e Secundária"
+/>
+
+<StorybookEmbed
+  storyId="components-banner--with-primary-action-only"
+  height={700}
+  showToolbar={false}
+  title="Banner - Apenas Primária"
 />
 
 ### Sem imagem
@@ -105,20 +120,18 @@ Quando a prop `image` é omitida, nenhuma área de imagem é renderizada.
 
 ```tsx live
 <Banner
-  size="large"
   title="Banner sem Imagem"
   description="Apenas título, descrição e botões."
-  buttons={[{ label: 'Ação', onClick: () => {} }]}
+  primaryAction={{ label: 'Ação', onClick: () => {} }}
 />
 ```
 
 ### Sem botões
 
-Quando a prop `buttons` é omitida ou vazia, nenhum botão é renderizado.
+Quando `primaryAction` e `secondaryAction` são omitidos, nenhum botão é renderizado.
 
 ```tsx live
 <Banner
-  size="large"
   title="Banner sem Botões"
   description="Apenas título e descrição."
   image="https://placehold.co/800x200"
@@ -131,16 +144,16 @@ Quando a prop `buttons` é omitida ou vazia, nenhum botão é renderizado.
 
 | Prop              | Tipo                                                   | Padrão      | Descrição                                                                               |
 | ----------------- | ------------------------------------------------------ | ----------- | --------------------------------------------------------------------------------------- |
-| `size`            | `'large' \| 'small'`                                   | —           | Layout do banner. **Obrigatório.**                                                       |
-| `type`            | `'default' \| 'warning' \| 'negative' \| 'emphasys'`  | `'default'` | Tipo visual com cores do Ocean DS.                                                      |
 | `title`           | `string`                                               | —           | Título principal exibido no banner. **Obrigatório.**                                    |
+| `size`            | `'large' \| 'small'`                                   | `'large'`   | Layout do banner.                                                                       |
+| `type`            | `'default' \| 'warning' \| 'negative' \| 'emphasys'`  | `'default'` | Tipo visual com cores do Ocean DS.                                                      |
 | `description`     | `string`                                               | —           | Texto descritivo abaixo do título (opcional).                                           |
 | `image`           | `string`                                               | —           | URL da imagem. Quando ausente, a área de imagem não é renderizada.                      |
-| `buttons`         | `ButtonProps[]`                                        | —           | Array de botões (máx. 2). Quando vazio ou ausente, nenhum botão é renderizado.         |
-| `backgroundColor` | `string`                                               | —           | Cor de fundo customizada que sobrescreve o padrão do tipo selecionado.                  |
+| `primaryAction`   | `ActionProps`                                          | —           | Ação primária. Variante do botão derivada do `type`.                                    |
+| `secondaryAction` | `ActionProps`                                          | —           | Ação secundária. Variante do botão derivada do `type`.                                  |
 | `className`       | `string`                                               | —           | Classes CSS adicionais para customização.                                               |
 
-### ButtonProps
+### ActionProps
 
 | Prop      | Tipo          | Descrição                                          |
 | --------- | ------------- | -------------------------------------------------- |

--- a/packages/ocean-docs/docs/components/banner.mdx
+++ b/packages/ocean-docs/docs/components/banner.mdx
@@ -45,6 +45,7 @@ Para documentação técnica detalhada, exemplos de uso e API completa, consulte
 
 ```tsx live
 <Banner
+  size="small"
   title="Título do Banner"
   description="Mensagem descritiva do banner."
   primaryAction={{ label: 'Saiba Mais', onClick: () => console.log('clicked') }}
@@ -57,8 +58,8 @@ Para documentação técnica detalhada, exemplos de uso e API completa, consulte
 
 O `size` define o layout do banner:
 
-- **`large`** *(padrão)* — a imagem ocupa a largura total acima do conteúdo.
-- **`small`** — a imagem fica à direita (82px) e o conteúdo à esquerda.
+- **`large`** _(padrão)_ — a imagem ocupa a largura total acima do conteúdo. **A imagem é obrigatória.**
+- **`small`** — a imagem fica à direita (82px) e o conteúdo à esquerda. A imagem é opcional.
 
 ```tsx live
 <Banner
@@ -82,22 +83,22 @@ O `size` define o layout do banner:
 
 ### Tipos (type)
 
-| Tipo        | Cor de fundo                   | Título                        | Descrição                     |
-| ----------- | ------------------------------ | ----------------------------- | ----------------------------- |
-| `default`   | `$color-interface-light-up`    | `$color-interface-dark-deep`  | `$color-interface-dark-down`  |
-| `warning`   | `$color-status-warning-up`     | `$color-interface-dark-deep`  | `$color-interface-dark-down`  |
-| `negative`  | `$color-status-negative-up`    | `$color-interface-dark-deep`  | `$color-interface-dark-down`  |
-| `emphasys`  | `$color-brand-primary-pure`    | `$color-interface-light-pure` | `$color-interface-light-up`   |
+| Tipo       | Cor de fundo                | Título                        | Descrição                    |
+| ---------- | --------------------------- | ----------------------------- | ---------------------------- |
+| `default`  | `$color-interface-light-up` | `$color-interface-dark-deep`  | `$color-interface-dark-down` |
+| `warning`  | `$color-status-warning-up`  | `$color-interface-dark-deep`  | `$color-interface-dark-down` |
+| `negative` | `$color-status-negative-up` | `$color-interface-dark-deep`  | `$color-interface-dark-down` |
+| `emphasys` | `$color-brand-primary-pure` | `$color-interface-light-pure` | `$color-interface-light-up`  |
 
 ### Variantes de botão por tipo
 
 A variante dos botões é derivada automaticamente do `type` — não é necessário especificá-la manualmente.
 
-| Tipo       | `primaryAction`   | `secondaryAction`  |
-| ---------- | ----------------- | ------------------ |
-| `default`  | `primary`         | `tertiary`         |
-| `warning`  | `primaryWarning`  | `tertiaryWarning`  |
-| `negative` | `primaryCritical` | `tertiaryCritical` |
+| Tipo       | `primaryAction`   | `secondaryAction`                                |
+| ---------- | ----------------- | ------------------------------------------------ |
+| `default`  | `primary`         | `tertiary`                                       |
+| `warning`  | `primaryWarning`  | `tertiaryWarning`                                |
+| `negative` | `primaryCritical` | `tertiaryCritical`                               |
 | `emphasys` | `secondary`       | `tertiary` (texto `$color-interface-light-pure`) |
 
 <StorybookEmbed
@@ -142,43 +143,43 @@ Quando `primaryAction` e `secondaryAction` são omitidos, nenhum botão é rende
 
 ### Props
 
-| Prop              | Tipo                                                   | Padrão      | Descrição                                                                               |
-| ----------------- | ------------------------------------------------------ | ----------- | --------------------------------------------------------------------------------------- |
-| `title`           | `string`                                               | —           | Título principal exibido no banner. **Obrigatório.**                                    |
-| `size`            | `'large' \| 'small'`                                   | `'large'`   | Layout do banner.                                                                       |
-| `type`            | `'default' \| 'warning' \| 'negative' \| 'emphasys'`  | `'default'` | Tipo visual com cores do Ocean DS.                                                      |
-| `description`     | `string`                                               | —           | Texto descritivo abaixo do título (opcional).                                           |
-| `image`           | `string`                                               | —           | URL da imagem. Quando ausente, a área de imagem não é renderizada.                      |
-| `primaryAction`   | `ActionProps`                                          | —           | Ação primária. Variante do botão derivada do `type`.                                    |
-| `secondaryAction` | `ActionProps`                                          | —           | Ação secundária. Variante do botão derivada do `type`.                                  |
-| `className`       | `string`                                               | —           | Classes CSS adicionais para customização.                                               |
+| Prop              | Tipo                                                 | Padrão      | Descrição                                                       |
+| ----------------- | ---------------------------------------------------- | ----------- | --------------------------------------------------------------- |
+| `title`           | `string`                                             | —           | Título principal exibido no banner. **Obrigatório.**            |
+| `size`            | `'large' \| 'small'`                                 | `'large'`   | Layout do banner.                                               |
+| `type`            | `'default' \| 'warning' \| 'negative' \| 'emphasys'` | `'default'` | Tipo visual com cores do Ocean DS.                              |
+| `description`     | `string`                                             | —           | Texto descritivo abaixo do título (opcional).                   |
+| `image`           | `string`                                             | —           | URL da imagem. **Obrigatória** em `large`; opcional em `small`. |
+| `primaryAction`   | `ActionProps`                                        | —           | Ação primária. Variante do botão derivada do `type`.            |
+| `secondaryAction` | `ActionProps`                                        | —           | Ação secundária. Variante do botão derivada do `type`.          |
+| `className`       | `string`                                             | —           | Classes CSS adicionais para customização.                       |
 
 ### ActionProps
 
-| Prop      | Tipo          | Descrição                                          |
-| --------- | ------------- | -------------------------------------------------- |
-| `label`   | `string`      | Texto exibido no botão.                            |
-| `onClick` | `() => void`  | Função chamada ao clicar no botão.                 |
+| Prop      | Tipo         | Descrição                          |
+| --------- | ------------ | ---------------------------------- |
+| `label`   | `string`     | Texto exibido no botão.            |
+| `onClick` | `() => void` | Função chamada ao clicar no botão. |
 
 ## CSS Classes
 
-| Classe                                    | Descrição                                            |
-| ----------------------------------------- | ---------------------------------------------------- |
-| `.ods-banner`                             | Classe base aplicada ao elemento raiz.               |
-| `.ods-banner--large`                      | Modificador de tamanho `large`.                      |
-| `.ods-banner--small`                      | Modificador de tamanho `small`.                      |
-| `.ods-banner--default`                    | Modificador de tipo `default`.                       |
-| `.ods-banner--warning`                    | Modificador de tipo `warning`.                       |
-| `.ods-banner--negative`                   | Modificador de tipo `negative`.                      |
-| `.ods-banner--emphasys`                   | Modificador de tipo `emphasys`.                      |
-| `.ods-banner__image-wrapper--top`         | Container da imagem no topo (tamanho `large`).       |
-| `.ods-banner__image-wrapper--side`        | Container da imagem lateral (tamanho `small`).       |
-| `.ods-banner__image`                      | Elemento `<img>` do banner.                          |
-| `.ods-banner__body`                       | Container que agrupa conteúdo e imagem lateral.      |
-| `.ods-banner__content`                    | Container do título, descrição e botões.             |
-| `.ods-banner__title`                      | Elemento de título do banner.                        |
-| `.ods-banner__description`                | Elemento de descrição do banner.                     |
-| `.ods-banner__actions`                    | Container dos botões de ação.                        |
+| Classe                             | Descrição                                       |
+| ---------------------------------- | ----------------------------------------------- |
+| `.ods-banner`                      | Classe base aplicada ao elemento raiz.          |
+| `.ods-banner--large`               | Modificador de tamanho `large`.                 |
+| `.ods-banner--small`               | Modificador de tamanho `small`.                 |
+| `.ods-banner--default`             | Modificador de tipo `default`.                  |
+| `.ods-banner--warning`             | Modificador de tipo `warning`.                  |
+| `.ods-banner--negative`            | Modificador de tipo `negative`.                 |
+| `.ods-banner--emphasys`            | Modificador de tipo `emphasys`.                 |
+| `.ods-banner__image-wrapper--top`  | Container da imagem no topo (tamanho `large`).  |
+| `.ods-banner__image-wrapper--side` | Container da imagem lateral (tamanho `small`).  |
+| `.ods-banner__image`               | Elemento `<img>` do banner.                     |
+| `.ods-banner__body`                | Container que agrupa conteúdo e imagem lateral. |
+| `.ods-banner__content`             | Container do título, descrição e botões.        |
+| `.ods-banner__title`               | Elemento de título do banner.                   |
+| `.ods-banner__description`         | Elemento de descrição do banner.                |
+| `.ods-banner__actions`             | Container dos botões de ação.                   |
 
 ## Quando Usar
 

--- a/packages/ocean-docs/docs/components/banner.mdx
+++ b/packages/ocean-docs/docs/components/banner.mdx
@@ -1,0 +1,191 @@
+---
+title: Banner
+---
+
+import { Banner } from '@useblu/ocean-react';
+import StorybookEmbed from '@site/src/components/StorybookEmbed';
+
+# Banner
+
+O componente Banner é usado para exibir comunicações destacadas — informativos, avisos, alertas ou chamadas de ação — com suporte a imagem, descrição e botões de ação.
+
+## Importação
+
+```tsx
+import { Banner } from '@useblu/ocean-react';
+```
+
+### Importação específica (recomendado para tree-shaking)
+
+```tsx
+import Banner from '@useblu/ocean-react/Banner';
+```
+
+### Importação de tipos TypeScript
+
+```tsx
+import type { BannerProps } from '@useblu/ocean-react';
+```
+
+## Playground Interativo
+
+Explore o componente Banner no playground interativo do Storybook:
+
+<StorybookEmbed
+  storyId="components-banner--usage"
+  height={500}
+  title="Banner - Playground Interativo"
+/>
+
+## Documentação Completa
+
+Para documentação técnica detalhada, exemplos de uso e API completa, consulte o **[Storybook do Banner](https://ocean-ds.github.io/ocean-web/?path=/docs/components-banner--docs)**.
+
+## Uso básico
+
+```tsx live
+<Banner
+  size="large"
+  title="Título do Banner"
+  description="Mensagem descritiva do banner."
+  buttons={[{ label: 'Saiba Mais', onClick: () => console.log('clicked') }]}
+/>
+```
+
+## Variações
+
+### Tamanhos (size)
+
+O `size` define o layout do banner:
+
+- **`large`** — a imagem ocupa a largura total acima do conteúdo.
+- **`small`** — a imagem fica à direita (25% da largura) e o conteúdo à esquerda.
+
+```tsx live
+<Banner
+  size="large"
+  title="Banner Large"
+  description="Imagem no topo, conteúdo abaixo."
+  image="https://placehold.co/800x200"
+  buttons={[{ label: 'Ação', onClick: () => {} }]}
+/>
+```
+
+```tsx live
+<Banner
+  size="small"
+  title="Banner Small"
+  description="Imagem à direita, conteúdo à esquerda."
+  image="https://placehold.co/200x150"
+  buttons={[{ label: 'Ação', onClick: () => {} }]}
+/>
+```
+
+### Tipos (type)
+
+| Tipo        | Cor de fundo                   | Cor do texto                |
+| ----------- | ------------------------------ | --------------------------- |
+| `default`   | `$color-interface-light-up`    | `$color-interface-dark-deep` |
+| `warning`   | `$color-status-warning-up`     | `$color-interface-dark-deep` |
+| `negative`  | `$color-status-negative-up`    | `$color-interface-dark-deep` |
+| `emphasys`  | `$color-brand-primary-pure`    | `$color-interface-light-pure` |
+
+Para o tipo `emphasys`, os botões usam a variante `inverse`.
+
+<StorybookEmbed
+  storyId="components-banner--types"
+  height={700}
+  showToolbar={false}
+  title="Banner - Tipos"
+/>
+
+### Sem imagem
+
+Quando a prop `image` é omitida, nenhuma área de imagem é renderizada.
+
+```tsx live
+<Banner
+  size="large"
+  title="Banner sem Imagem"
+  description="Apenas título, descrição e botões."
+  buttons={[{ label: 'Ação', onClick: () => {} }]}
+/>
+```
+
+### Sem botões
+
+Quando a prop `buttons` é omitida ou vazia, nenhum botão é renderizado.
+
+```tsx live
+<Banner
+  size="large"
+  title="Banner sem Botões"
+  description="Apenas título e descrição."
+  image="https://placehold.co/800x200"
+/>
+```
+
+## API
+
+### Props
+
+| Prop              | Tipo                                                   | Padrão      | Descrição                                                                               |
+| ----------------- | ------------------------------------------------------ | ----------- | --------------------------------------------------------------------------------------- |
+| `size`            | `'large' \| 'small'`                                   | —           | Layout do banner. **Obrigatório.**                                                       |
+| `type`            | `'default' \| 'warning' \| 'negative' \| 'emphasys'`  | `'default'` | Tipo visual com cores do Ocean DS.                                                      |
+| `title`           | `string`                                               | —           | Título principal exibido no banner. **Obrigatório.**                                    |
+| `description`     | `string`                                               | —           | Texto descritivo abaixo do título (opcional).                                           |
+| `image`           | `string`                                               | —           | URL da imagem. Quando ausente, a área de imagem não é renderizada.                      |
+| `buttons`         | `ButtonProps[]`                                        | —           | Array de botões (máx. 2). Quando vazio ou ausente, nenhum botão é renderizado.         |
+| `backgroundColor` | `string`                                               | —           | Cor de fundo customizada que sobrescreve o padrão do tipo selecionado.                  |
+| `className`       | `string`                                               | —           | Classes CSS adicionais para customização.                                               |
+
+### ButtonProps
+
+| Prop      | Tipo          | Descrição                                          |
+| --------- | ------------- | -------------------------------------------------- |
+| `label`   | `string`      | Texto exibido no botão.                            |
+| `onClick` | `() => void`  | Função chamada ao clicar no botão.                 |
+
+## CSS Classes
+
+| Classe                                    | Descrição                                            |
+| ----------------------------------------- | ---------------------------------------------------- |
+| `.ods-banner`                             | Classe base aplicada ao elemento raiz.               |
+| `.ods-banner--large`                      | Modificador de tamanho `large`.                      |
+| `.ods-banner--small`                      | Modificador de tamanho `small`.                      |
+| `.ods-banner--default`                    | Modificador de tipo `default`.                       |
+| `.ods-banner--warning`                    | Modificador de tipo `warning`.                       |
+| `.ods-banner--negative`                   | Modificador de tipo `negative`.                      |
+| `.ods-banner--emphasys`                   | Modificador de tipo `emphasys`.                      |
+| `.ods-banner__image-wrapper--top`         | Container da imagem no topo (tamanho `large`).       |
+| `.ods-banner__image-wrapper--side`        | Container da imagem lateral (tamanho `small`).       |
+| `.ods-banner__image`                      | Elemento `<img>` do banner.                          |
+| `.ods-banner__body`                       | Container que agrupa conteúdo e imagem lateral.      |
+| `.ods-banner__content`                    | Container do título, descrição e botões.             |
+| `.ods-banner__title`                      | Elemento de título do banner.                        |
+| `.ods-banner__description`                | Elemento de descrição do banner.                     |
+| `.ods-banner__actions`                    | Container dos botões de ação.                        |
+
+## Quando Usar
+
+### Ideal para:
+
+- **Comunicações destacadas**: avisos, promoções ou informações importantes.
+- **Chamadas de ação**: incentivar o usuário a realizar uma ação específica.
+- **Onboarding**: guiar usuários com contexto visual e textual.
+- **Alertas visuais**: distinção por cor para tipos `warning` e `negative`.
+
+### Evite para:
+
+- Notificações descartáveis — use o componente **Alert** para isso.
+- Mensagens temporárias — use o componente **Snackbar**.
+- Navegação principal do sistema.
+- Múltiplos banners na mesma tela que competem entre si.
+
+## Links relacionados
+
+- [Alert](/components/alert) - Para notificações inline descartáveis
+- [Snackbar](/components/snackbar) - Para mensagens temporárias
+- [Button](/components/button) - Para ações isoladas
+- [Storybook - Banner](https://ocean-ds.github.io/ocean-web/?path=/docs/components-banner--docs) - Documentação técnica

--- a/packages/ocean-react/src/Banner/Banner.tsx
+++ b/packages/ocean-react/src/Banner/Banner.tsx
@@ -9,14 +9,7 @@ export type ActionProps = {
   onClick: () => void;
 };
 
-export type BannerProps = {
-  /**
-   * Determines the layout of the banner.
-   * - `large`: image on top (full-width), then title/description/buttons below.
-   * - `small`: image on the right (82px width), title/description/buttons on the left.
-   * @default 'large'
-   */
-  size?: 'large' | 'small';
+type BannerCommonProps = {
   /**
    * Determines the visual type of the banner.
    * @default 'default'
@@ -31,10 +24,6 @@ export type BannerProps = {
    */
   description?: string;
   /**
-   * Optional image URL. When absent, no image area is rendered.
-   */
-  image?: string;
-  /**
    * Primary action button. Variant is derived from `type`.
    */
   primaryAction?: ActionProps;
@@ -43,6 +32,25 @@ export type BannerProps = {
    */
   secondaryAction?: ActionProps;
 } & React.ComponentPropsWithoutRef<'div'>;
+
+type BannerLargeProps = BannerCommonProps & {
+  /**
+   * Large layout: image on top (full-width), content below. Image is required.
+   * @default 'large'
+   */
+  size?: 'large';
+  /** Required image URL displayed above the content. */
+  image: string;
+};
+
+type BannerSmallProps = BannerCommonProps & {
+  /** Small layout: content on the left, optional image on the right (82px). */
+  size: 'small';
+  /** Optional image URL displayed to the right of the content. */
+  image?: string;
+};
+
+export type BannerProps = BannerLargeProps | BannerSmallProps;
 
 const PRIMARY_VARIANT_MAP = {
   default: 'primary',
@@ -77,7 +85,12 @@ const Banner = React.forwardRef<HTMLDivElement, BannerProps>(
     const hasActions = primaryAction || secondaryAction;
 
     const imageEl = image ? (
-      <img className="ods-banner__image" src={image} alt="" aria-hidden="true" />
+      <img
+        className="ods-banner__image"
+        src={image}
+        alt=""
+        aria-hidden="true"
+      />
     ) : null;
 
     return (

--- a/packages/ocean-react/src/Banner/Banner.tsx
+++ b/packages/ocean-react/src/Banner/Banner.tsx
@@ -55,7 +55,7 @@ const SECONDARY_VARIANT_MAP = {
   default: 'tertiary',
   warning: 'tertiaryWarning',
   negative: 'tertiaryCritical',
-  emphasys: 'inverse',
+  emphasys: 'tertiary',
 } as const;
 
 const Banner = React.forwardRef<HTMLDivElement, BannerProps>(

--- a/packages/ocean-react/src/Banner/Banner.tsx
+++ b/packages/ocean-react/src/Banner/Banner.tsx
@@ -105,9 +105,9 @@ const Banner = React.forwardRef<HTMLDivElement, BannerProps>(
 
             {visibleButtons && visibleButtons.length > 0 && (
               <div className="ods-banner__actions">
-                {visibleButtons.map((btn, index) => (
+                {visibleButtons.map((btn) => (
                   <Button
-                    key={index}
+                    key={btn.label}
                     size="sm"
                     variant={buttonVariant}
                     onClick={btn.onClick}

--- a/packages/ocean-react/src/Banner/Banner.tsx
+++ b/packages/ocean-react/src/Banner/Banner.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import classNames from 'classnames';
+
+import Button from '../Button';
+
+export type ButtonProps = {
+  /**
+   * The label text of the button.
+   */
+  label: string;
+  /**
+   * The action triggered when the button is clicked.
+   */
+  onClick: () => void;
+};
+
+export type BannerProps = {
+  /**
+   * Determines the layout of the banner.
+   * - `large`: image on top (full-width), then title/description/buttons below.
+   * - `small`: image on the right (25% width), title/description/buttons on the left.
+   */
+  size: 'large' | 'small';
+  /**
+   * Determines the visual type of the banner.
+   * @default 'default'
+   */
+  type?: 'default' | 'warning' | 'negative' | 'emphasys';
+  /**
+   * The main title displayed in the banner.
+   */
+  title: string;
+  /**
+   * Optional description text displayed below the title.
+   */
+  description?: string;
+  /**
+   * Optional image URL. When absent, no image area is rendered.
+   */
+  image?: string;
+  /**
+   * Optional array of buttons (max 2). When empty or absent, no buttons are rendered.
+   */
+  buttons?: ButtonProps[];
+  /**
+   * Optional custom background color that overrides the type default.
+   */
+  backgroundColor?: string;
+} & React.ComponentPropsWithoutRef<'div'>;
+
+const Banner = React.forwardRef<HTMLDivElement, BannerProps>(
+  (
+    {
+      size,
+      type = 'default',
+      title,
+      description,
+      image,
+      buttons,
+      backgroundColor,
+      className,
+      style,
+      ...rest
+    },
+    ref
+  ) => {
+    const isEmphasys = type === 'emphasys';
+    const buttonVariant = isEmphasys ? 'inverse' : 'primary';
+    const visibleButtons = buttons?.slice(0, 2);
+
+    const inlineStyle: React.CSSProperties = {
+      ...style,
+      ...(backgroundColor ? { backgroundColor } : {}),
+    };
+
+    return (
+      <div
+        ref={ref}
+        {...rest}
+        className={classNames(
+          'ods-banner',
+          `ods-banner--${size}`,
+          `ods-banner--${type}`,
+          className
+        )}
+        style={inlineStyle}
+      >
+        {image && size === 'large' && (
+          <div className="ods-banner__image-wrapper ods-banner__image-wrapper--top">
+            <img
+              className="ods-banner__image"
+              src={image}
+              alt=""
+              aria-hidden="true"
+            />
+          </div>
+        )}
+
+        <div className="ods-banner__body">
+          <div className="ods-banner__content">
+            <div className="ods-banner__title">{title}</div>
+
+            {description && (
+              <div className="ods-banner__description">{description}</div>
+            )}
+
+            {visibleButtons && visibleButtons.length > 0 && (
+              <div className="ods-banner__actions">
+                {visibleButtons.map((btn, index) => (
+                  <Button
+                    key={index}
+                    size="sm"
+                    variant={buttonVariant}
+                    onClick={btn.onClick}
+                  >
+                    {btn.label}
+                  </Button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {image && size === 'small' && (
+            <div className="ods-banner__image-wrapper ods-banner__image-wrapper--side">
+              <img
+                className="ods-banner__image"
+                src={image}
+                alt=""
+                aria-hidden="true"
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+);
+
+Banner.displayName = 'Banner';
+
+export default Banner;

--- a/packages/ocean-react/src/Banner/Banner.tsx
+++ b/packages/ocean-react/src/Banner/Banner.tsx
@@ -73,6 +73,10 @@ const Banner = React.forwardRef<HTMLDivElement, BannerProps>(
       ...(backgroundColor ? { backgroundColor } : {}),
     };
 
+    const imageEl = image ? (
+      <img className="ods-banner__image" src={image} alt="" aria-hidden="true" />
+    ) : null;
+
     return (
       <div
         ref={ref}
@@ -85,14 +89,9 @@ const Banner = React.forwardRef<HTMLDivElement, BannerProps>(
         )}
         style={inlineStyle}
       >
-        {image && size === 'large' && (
+        {imageEl && size === 'large' && (
           <div className="ods-banner__image-wrapper ods-banner__image-wrapper--top">
-            <img
-              className="ods-banner__image"
-              src={image}
-              alt=""
-              aria-hidden="true"
-            />
+            {imageEl}
           </div>
         )}
 
@@ -120,14 +119,9 @@ const Banner = React.forwardRef<HTMLDivElement, BannerProps>(
             )}
           </div>
 
-          {image && size === 'small' && (
+          {imageEl && size === 'small' && (
             <div className="ods-banner__image-wrapper ods-banner__image-wrapper--side">
-              <img
-                className="ods-banner__image"
-                src={image}
-                alt=""
-                aria-hidden="true"
-              />
+              {imageEl}
             </div>
           )}
         </div>

--- a/packages/ocean-react/src/Banner/Banner.tsx
+++ b/packages/ocean-react/src/Banner/Banner.tsx
@@ -2,15 +2,10 @@ import React from 'react';
 import classNames from 'classnames';
 
 import Button from '../Button';
+import Typography from '../Typography';
 
-export type ButtonProps = {
-  /**
-   * The label text of the button.
-   */
+export type ActionProps = {
   label: string;
-  /**
-   * The action triggered when the button is clicked.
-   */
   onClick: () => void;
 };
 
@@ -18,9 +13,10 @@ export type BannerProps = {
   /**
    * Determines the layout of the banner.
    * - `large`: image on top (full-width), then title/description/buttons below.
-   * - `small`: image on the right (25% width), title/description/buttons on the left.
+   * - `small`: image on the right (82px width), title/description/buttons on the left.
+   * @default 'large'
    */
-  size: 'large' | 'small';
+  size?: 'large' | 'small';
   /**
    * Determines the visual type of the banner.
    * @default 'default'
@@ -39,39 +35,46 @@ export type BannerProps = {
    */
   image?: string;
   /**
-   * Optional array of buttons (max 2). When empty or absent, no buttons are rendered.
+   * Primary action button. Variant is derived from `type`.
    */
-  buttons?: ButtonProps[];
+  primaryAction?: ActionProps;
   /**
-   * Optional custom background color that overrides the type default.
+   * Secondary action button. Variant is derived from `type`.
    */
-  backgroundColor?: string;
+  secondaryAction?: ActionProps;
 } & React.ComponentPropsWithoutRef<'div'>;
+
+const PRIMARY_VARIANT_MAP = {
+  default: 'primary',
+  warning: 'primaryWarning',
+  negative: 'primaryCritical',
+  emphasys: 'secondary',
+} as const;
+
+const SECONDARY_VARIANT_MAP = {
+  default: 'tertiary',
+  warning: 'tertiaryWarning',
+  negative: 'tertiaryCritical',
+  emphasys: 'inverse',
+} as const;
 
 const Banner = React.forwardRef<HTMLDivElement, BannerProps>(
   (
     {
-      size,
+      size = 'large',
       type = 'default',
       title,
       description,
       image,
-      buttons,
-      backgroundColor,
+      primaryAction,
+      secondaryAction,
       className,
-      style,
       ...rest
     },
     ref
   ) => {
     const isEmphasys = type === 'emphasys';
-    const buttonVariant = isEmphasys ? 'inverse' : 'primary';
-    const visibleButtons = buttons?.slice(0, 2);
-
-    const inlineStyle: React.CSSProperties = {
-      ...style,
-      ...(backgroundColor ? { backgroundColor } : {}),
-    };
+    const hasActions = primaryAction || secondaryAction;
 
     const imageEl = image ? (
       <img className="ods-banner__image" src={image} alt="" aria-hidden="true" />
@@ -87,7 +90,6 @@ const Banner = React.forwardRef<HTMLDivElement, BannerProps>(
           `ods-banner--${type}`,
           className
         )}
-        style={inlineStyle}
       >
         {imageEl && size === 'large' && (
           <div className="ods-banner__image-wrapper ods-banner__image-wrapper--top">
@@ -97,24 +99,44 @@ const Banner = React.forwardRef<HTMLDivElement, BannerProps>(
 
         <div className="ods-banner__body">
           <div className="ods-banner__content">
-            <div className="ods-banner__title">{title}</div>
+            <Typography
+              variant="heading4"
+              inverse={isEmphasys}
+              className="ods-banner__title"
+            >
+              {title}
+            </Typography>
 
             {description && (
-              <div className="ods-banner__description">{description}</div>
+              <Typography
+                variant="description"
+                inverse={isEmphasys}
+                className="ods-banner__description"
+              >
+                {description}
+              </Typography>
             )}
 
-            {visibleButtons && visibleButtons.length > 0 && (
+            {hasActions && (
               <div className="ods-banner__actions">
-                {visibleButtons.map((btn) => (
+                {primaryAction && (
                   <Button
-                    key={btn.label}
                     size="sm"
-                    variant={buttonVariant}
-                    onClick={btn.onClick}
+                    variant={PRIMARY_VARIANT_MAP[type]}
+                    onClick={primaryAction.onClick}
                   >
-                    {btn.label}
+                    {primaryAction.label}
                   </Button>
-                ))}
+                )}
+                {secondaryAction && (
+                  <Button
+                    size="sm"
+                    variant={SECONDARY_VARIANT_MAP[type]}
+                    onClick={secondaryAction.onClick}
+                  >
+                    {secondaryAction.label}
+                  </Button>
+                )}
               </div>
             )}
           </div>

--- a/packages/ocean-react/src/Banner/__tests__/Banner.test.tsx
+++ b/packages/ocean-react/src/Banner/__tests__/Banner.test.tsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import Banner, { BannerProps } from '../Banner';
+
+const setup = (props: Partial<BannerProps> = {}) => {
+  const defaultProps: BannerProps = {
+    size: 'large',
+    title: 'Test Title',
+    ...props,
+  };
+  return render(<Banner {...defaultProps} />);
+};
+
+describe('Banner', () => {
+  test('renders the title', () => {
+    setup({ title: 'Hello Banner' });
+    expect(screen.getByText('Hello Banner')).toBeInTheDocument();
+  });
+
+  test('renders the description when provided', () => {
+    setup({ description: 'Some description text' });
+    expect(screen.getByText('Some description text')).toBeInTheDocument();
+  });
+
+  test('does not render the description when absent', () => {
+    setup();
+    expect(screen.queryByText('Some description text')).not.toBeInTheDocument();
+  });
+
+  test('renders the image when provided (large)', () => {
+    setup({ size: 'large', image: 'http://example.com/img.png' });
+    const img = document.querySelector('.ods-banner__image') as HTMLImageElement;
+    expect(img).toBeInTheDocument();
+    expect(img.src).toContain('http://example.com/img.png');
+  });
+
+  test('renders the image when provided (small)', () => {
+    setup({ size: 'small', image: 'http://example.com/img.png' });
+    const img = document.querySelector('.ods-banner__image') as HTMLImageElement;
+    expect(img).toBeInTheDocument();
+    expect(img.src).toContain('http://example.com/img.png');
+  });
+
+  test('does not render the image area when image is absent', () => {
+    setup();
+    expect(document.querySelector('.ods-banner__image')).not.toBeInTheDocument();
+  });
+
+  test('renders buttons when provided', () => {
+    setup({
+      buttons: [
+        { label: 'Button One', onClick: jest.fn() },
+        { label: 'Button Two', onClick: jest.fn() },
+      ],
+    });
+    expect(screen.getByText('Button One')).toBeInTheDocument();
+    expect(screen.getByText('Button Two')).toBeInTheDocument();
+  });
+
+  test('does not render buttons when buttons prop is absent', () => {
+    setup();
+    expect(document.querySelector('.ods-banner__actions')).not.toBeInTheDocument();
+  });
+
+  test('does not render buttons when buttons array is empty', () => {
+    setup({ buttons: [] });
+    expect(document.querySelector('.ods-banner__actions')).not.toBeInTheDocument();
+  });
+
+  test('renders at most 2 buttons even when more are provided', () => {
+    setup({
+      buttons: [
+        { label: 'Btn 1', onClick: jest.fn() },
+        { label: 'Btn 2', onClick: jest.fn() },
+        { label: 'Btn 3', onClick: jest.fn() },
+      ],
+    });
+    const buttons = document.querySelectorAll('.ods-banner__actions .ods-btn');
+    expect(buttons.length).toBe(2);
+    expect(screen.queryByText('Btn 3')).not.toBeInTheDocument();
+  });
+
+  test('calls onClick when a button is clicked', () => {
+    const mockFn = jest.fn();
+    setup({
+      buttons: [{ label: 'Click Me', onClick: mockFn }],
+    });
+    fireEvent.click(screen.getByText('Click Me'));
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  test('applies size class for large', () => {
+    setup({ size: 'large' });
+    expect(document.querySelector('.ods-banner--large')).toBeInTheDocument();
+  });
+
+  test('applies size class for small', () => {
+    setup({ size: 'small' });
+    expect(document.querySelector('.ods-banner--small')).toBeInTheDocument();
+  });
+
+  test('applies default type class', () => {
+    setup({ type: 'default' });
+    expect(document.querySelector('.ods-banner--default')).toBeInTheDocument();
+  });
+
+  test('applies warning type class', () => {
+    setup({ type: 'warning' });
+    expect(document.querySelector('.ods-banner--warning')).toBeInTheDocument();
+  });
+
+  test('applies negative type class', () => {
+    setup({ type: 'negative' });
+    expect(document.querySelector('.ods-banner--negative')).toBeInTheDocument();
+  });
+
+  test('applies emphasys type class', () => {
+    setup({ type: 'emphasys' });
+    expect(document.querySelector('.ods-banner--emphasys')).toBeInTheDocument();
+  });
+
+  test('renders inverse button variant for emphasys type', () => {
+    setup({
+      type: 'emphasys',
+      buttons: [{ label: 'Emphasys Btn', onClick: jest.fn() }],
+    });
+    const btn = document.querySelector('.ods-btn--inverse');
+    expect(btn).toBeInTheDocument();
+  });
+
+  test('renders primary button variant for default type', () => {
+    setup({
+      type: 'default',
+      buttons: [{ label: 'Default Btn', onClick: jest.fn() }],
+    });
+    const btn = document.querySelector('.ods-btn--primary');
+    expect(btn).toBeInTheDocument();
+  });
+
+  test('applies custom backgroundColor via inline style', () => {
+    setup({ backgroundColor: 'rgb(255, 0, 0)' });
+    const banner = document.querySelector('.ods-banner') as HTMLElement;
+    expect(banner.style.backgroundColor).toBe('rgb(255, 0, 0)');
+  });
+
+  test('forwards extra className', () => {
+    setup({ className: 'my-custom-class' });
+    expect(document.querySelector('.my-custom-class')).toBeInTheDocument();
+  });
+
+  test('renders image in top wrapper for large size', () => {
+    setup({ size: 'large', image: 'http://example.com/img.png' });
+    expect(
+      document.querySelector('.ods-banner__image-wrapper--top')
+    ).toBeInTheDocument();
+  });
+
+  test('renders image in side wrapper for small size', () => {
+    setup({ size: 'small', image: 'http://example.com/img.png' });
+    expect(
+      document.querySelector('.ods-banner__image-wrapper--side')
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/ocean-react/src/Banner/__tests__/Banner.test.tsx
+++ b/packages/ocean-react/src/Banner/__tests__/Banner.test.tsx
@@ -5,7 +5,6 @@ import Banner, { BannerProps } from '../Banner';
 
 const setup = (props: Partial<BannerProps> = {}) => {
   const defaultProps: BannerProps = {
-    size: 'large',
     title: 'Test Title',
     ...props,
   };
@@ -43,47 +42,35 @@ describe('Banner', () => {
     expect(document.querySelector('.ods-banner__image')).not.toBeInTheDocument();
   });
 
-  test('renders buttons when provided', () => {
-    setup({
-      buttons: [
-        { label: 'Button One', onClick: jest.fn() },
-        { label: 'Button Two', onClick: jest.fn() },
-      ],
-    });
-    expect(screen.getByText('Button One')).toBeInTheDocument();
-    expect(screen.getByText('Button Two')).toBeInTheDocument();
+  test('renders primaryAction button when provided', () => {
+    setup({ primaryAction: { label: 'Primary', onClick: jest.fn() } });
+    expect(screen.getByText('Primary')).toBeInTheDocument();
   });
 
-  test('does not render buttons when buttons prop is absent', () => {
+  test('renders both actions when provided', () => {
+    setup({
+      primaryAction: { label: 'Primary', onClick: jest.fn() },
+      secondaryAction: { label: 'Secondary', onClick: jest.fn() },
+    });
+    expect(screen.getByText('Primary')).toBeInTheDocument();
+    expect(screen.getByText('Secondary')).toBeInTheDocument();
+  });
+
+  test('does not render actions area when no actions are provided', () => {
     setup();
     expect(document.querySelector('.ods-banner__actions')).not.toBeInTheDocument();
   });
 
-  test('does not render buttons when buttons array is empty', () => {
-    setup({ buttons: [] });
-    expect(document.querySelector('.ods-banner__actions')).not.toBeInTheDocument();
-  });
-
-  test('renders at most 2 buttons even when more are provided', () => {
-    setup({
-      buttons: [
-        { label: 'Btn 1', onClick: jest.fn() },
-        { label: 'Btn 2', onClick: jest.fn() },
-        { label: 'Btn 3', onClick: jest.fn() },
-      ],
-    });
-    const buttons = document.querySelectorAll('.ods-banner__actions .ods-btn');
-    expect(buttons.length).toBe(2);
-    expect(screen.queryByText('Btn 3')).not.toBeInTheDocument();
-  });
-
-  test('calls onClick when a button is clicked', () => {
+  test('calls onClick when primaryAction button is clicked', () => {
     const mockFn = jest.fn();
-    setup({
-      buttons: [{ label: 'Click Me', onClick: mockFn }],
-    });
+    setup({ primaryAction: { label: 'Click Me', onClick: mockFn } });
     fireEvent.click(screen.getByText('Click Me'));
     expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  test('defaults size to large when not specified', () => {
+    setup();
+    expect(document.querySelector('.ods-banner--large')).toBeInTheDocument();
   });
 
   test.each(['large', 'small'] as const)('applies %s size class', (size) => {
@@ -100,18 +87,22 @@ describe('Banner', () => {
   );
 
   test.each([
-    ['emphasys', '.ods-btn--inverse'],
-    ['default', '.ods-btn--primary'],
-  ] as const)('renders correct button variant for %s type', (type, selector) => {
-    setup({ type, buttons: [{ label: 'Btn', onClick: jest.fn() }] });
-    expect(document.querySelector(selector)).toBeInTheDocument();
-  });
-
-  test('applies custom backgroundColor via inline style', () => {
-    setup({ backgroundColor: 'rgb(255, 0, 0)' });
-    const banner = document.querySelector('.ods-banner') as HTMLElement;
-    expect(banner).toHaveStyle('background-color: rgb(255, 0, 0)');
-  });
+    ['default', '.ods-btn--primary', '.ods-btn--tertiary'],
+    ['warning', '.ods-btn--primary-warning', '.ods-btn--tertiary-warning'],
+    ['negative', '.ods-btn--primary-critical', '.ods-btn--tertiary-critical'],
+    ['emphasys', '.ods-btn--secondary', '.ods-btn--inverse'],
+  ] as const)(
+    'renders correct button variants for %s type',
+    (type, primarySelector, secondarySelector) => {
+      setup({
+        type,
+        primaryAction: { label: 'Primary', onClick: jest.fn() },
+        secondaryAction: { label: 'Secondary', onClick: jest.fn() },
+      });
+      expect(document.querySelector(primarySelector)).toBeInTheDocument();
+      expect(document.querySelector(secondarySelector)).toBeInTheDocument();
+    }
+  );
 
   test('forwards extra className', () => {
     setup({ className: 'my-custom-class' });

--- a/packages/ocean-react/src/Banner/__tests__/Banner.test.tsx
+++ b/packages/ocean-react/src/Banner/__tests__/Banner.test.tsx
@@ -28,19 +28,15 @@ describe('Banner', () => {
     expect(screen.queryByText('Some description text')).not.toBeInTheDocument();
   });
 
-  test('renders the image when provided (large)', () => {
-    setup({ size: 'large', image: 'http://example.com/img.png' });
-    const img = document.querySelector('.ods-banner__image') as HTMLImageElement;
-    expect(img).toBeInTheDocument();
-    expect(img.src).toContain('http://example.com/img.png');
-  });
-
-  test('renders the image when provided (small)', () => {
-    setup({ size: 'small', image: 'http://example.com/img.png' });
-    const img = document.querySelector('.ods-banner__image') as HTMLImageElement;
-    expect(img).toBeInTheDocument();
-    expect(img.src).toContain('http://example.com/img.png');
-  });
+  test.each(['large', 'small'] as const)(
+    'renders the image when provided (%s)',
+    (size) => {
+      setup({ size, image: 'http://example.com/img.png' });
+      const img = document.querySelector('.ods-banner__image') as HTMLImageElement;
+      expect(img).toBeInTheDocument();
+      expect(img.src).toContain('http://example.com/img.png');
+    }
+  );
 
   test('does not render the image area when image is absent', () => {
     setup();
@@ -90,52 +86,25 @@ describe('Banner', () => {
     expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
-  test('applies size class for large', () => {
-    setup({ size: 'large' });
-    expect(document.querySelector('.ods-banner--large')).toBeInTheDocument();
+  test.each(['large', 'small'] as const)('applies %s size class', (size) => {
+    setup({ size });
+    expect(document.querySelector(`.ods-banner--${size}`)).toBeInTheDocument();
   });
 
-  test('applies size class for small', () => {
-    setup({ size: 'small' });
-    expect(document.querySelector('.ods-banner--small')).toBeInTheDocument();
-  });
+  test.each(['default', 'warning', 'negative', 'emphasys'] as const)(
+    'applies %s type class',
+    (type) => {
+      setup({ type });
+      expect(document.querySelector(`.ods-banner--${type}`)).toBeInTheDocument();
+    }
+  );
 
-  test('applies default type class', () => {
-    setup({ type: 'default' });
-    expect(document.querySelector('.ods-banner--default')).toBeInTheDocument();
-  });
-
-  test('applies warning type class', () => {
-    setup({ type: 'warning' });
-    expect(document.querySelector('.ods-banner--warning')).toBeInTheDocument();
-  });
-
-  test('applies negative type class', () => {
-    setup({ type: 'negative' });
-    expect(document.querySelector('.ods-banner--negative')).toBeInTheDocument();
-  });
-
-  test('applies emphasys type class', () => {
-    setup({ type: 'emphasys' });
-    expect(document.querySelector('.ods-banner--emphasys')).toBeInTheDocument();
-  });
-
-  test('renders inverse button variant for emphasys type', () => {
-    setup({
-      type: 'emphasys',
-      buttons: [{ label: 'Emphasys Btn', onClick: jest.fn() }],
-    });
-    const btn = document.querySelector('.ods-btn--inverse');
-    expect(btn).toBeInTheDocument();
-  });
-
-  test('renders primary button variant for default type', () => {
-    setup({
-      type: 'default',
-      buttons: [{ label: 'Default Btn', onClick: jest.fn() }],
-    });
-    const btn = document.querySelector('.ods-btn--primary');
-    expect(btn).toBeInTheDocument();
+  test.each([
+    ['emphasys', '.ods-btn--inverse'],
+    ['default', '.ods-btn--primary'],
+  ] as const)('renders correct button variant for %s type', (type, selector) => {
+    setup({ type, buttons: [{ label: 'Btn', onClick: jest.fn() }] });
+    expect(document.querySelector(selector)).toBeInTheDocument();
   });
 
   test('applies custom backgroundColor via inline style', () => {
@@ -149,17 +118,11 @@ describe('Banner', () => {
     expect(document.querySelector('.my-custom-class')).toBeInTheDocument();
   });
 
-  test('renders image in top wrapper for large size', () => {
-    setup({ size: 'large', image: 'http://example.com/img.png' });
-    expect(
-      document.querySelector('.ods-banner__image-wrapper--top')
-    ).toBeInTheDocument();
-  });
-
-  test('renders image in side wrapper for small size', () => {
-    setup({ size: 'small', image: 'http://example.com/img.png' });
-    expect(
-      document.querySelector('.ods-banner__image-wrapper--side')
-    ).toBeInTheDocument();
+  test.each([
+    ['large', '.ods-banner__image-wrapper--top'],
+    ['small', '.ods-banner__image-wrapper--side'],
+  ] as const)('renders image in correct wrapper for %s size', (size, selector) => {
+    setup({ size, image: 'http://example.com/img.png' });
+    expect(document.querySelector(selector)).toBeInTheDocument();
   });
 });

--- a/packages/ocean-react/src/Banner/__tests__/Banner.test.tsx
+++ b/packages/ocean-react/src/Banner/__tests__/Banner.test.tsx
@@ -90,7 +90,7 @@ describe('Banner', () => {
     ['default', '.ods-btn--primary', '.ods-btn--tertiary'],
     ['warning', '.ods-btn--primary-warning', '.ods-btn--tertiary-warning'],
     ['negative', '.ods-btn--primary-critical', '.ods-btn--tertiary-critical'],
-    ['emphasys', '.ods-btn--secondary', '.ods-btn--inverse'],
+    ['emphasys', '.ods-btn--secondary', '.ods-btn--tertiary'],
   ] as const)(
     'renders correct button variants for %s type',
     (type, primarySelector, secondarySelector) => {

--- a/packages/ocean-react/src/Banner/__tests__/Banner.test.tsx
+++ b/packages/ocean-react/src/Banner/__tests__/Banner.test.tsx
@@ -110,7 +110,7 @@ describe('Banner', () => {
   test('applies custom backgroundColor via inline style', () => {
     setup({ backgroundColor: 'rgb(255, 0, 0)' });
     const banner = document.querySelector('.ods-banner') as HTMLElement;
-    expect(banner.style.backgroundColor).toBe('rgb(255, 0, 0)');
+    expect(banner).toHaveStyle('background-color: rgb(255, 0, 0)');
   });
 
   test('forwards extra className', () => {

--- a/packages/ocean-react/src/Banner/__tests__/Banner.test.tsx
+++ b/packages/ocean-react/src/Banner/__tests__/Banner.test.tsx
@@ -6,8 +6,9 @@ import Banner, { BannerProps } from '../Banner';
 const setup = (props: Partial<BannerProps> = {}) => {
   const defaultProps: BannerProps = {
     title: 'Test Title',
+    image: 'http://example.com/img.png',
     ...props,
-  };
+  } as BannerProps;
   return render(<Banner {...defaultProps} />);
 };
 
@@ -31,15 +32,19 @@ describe('Banner', () => {
     'renders the image when provided (%s)',
     (size) => {
       setup({ size, image: 'http://example.com/img.png' });
-      const img = document.querySelector('.ods-banner__image') as HTMLImageElement;
+      const img = document.querySelector(
+        '.ods-banner__image'
+      ) as HTMLImageElement;
       expect(img).toBeInTheDocument();
       expect(img.src).toContain('http://example.com/img.png');
     }
   );
 
-  test('does not render the image area when image is absent', () => {
-    setup();
-    expect(document.querySelector('.ods-banner__image')).not.toBeInTheDocument();
+  test('does not render the image area when image is absent (small)', () => {
+    setup({ size: 'small', image: undefined });
+    expect(
+      document.querySelector('.ods-banner__image')
+    ).not.toBeInTheDocument();
   });
 
   test('renders primaryAction button when provided', () => {
@@ -58,7 +63,9 @@ describe('Banner', () => {
 
   test('does not render actions area when no actions are provided', () => {
     setup();
-    expect(document.querySelector('.ods-banner__actions')).not.toBeInTheDocument();
+    expect(
+      document.querySelector('.ods-banner__actions')
+    ).not.toBeInTheDocument();
   });
 
   test('calls onClick when primaryAction button is clicked', () => {
@@ -82,7 +89,9 @@ describe('Banner', () => {
     'applies %s type class',
     (type) => {
       setup({ type });
-      expect(document.querySelector(`.ods-banner--${type}`)).toBeInTheDocument();
+      expect(
+        document.querySelector(`.ods-banner--${type}`)
+      ).toBeInTheDocument();
     }
   );
 
@@ -112,8 +121,11 @@ describe('Banner', () => {
   test.each([
     ['large', '.ods-banner__image-wrapper--top'],
     ['small', '.ods-banner__image-wrapper--side'],
-  ] as const)('renders image in correct wrapper for %s size', (size, selector) => {
-    setup({ size, image: 'http://example.com/img.png' });
-    expect(document.querySelector(selector)).toBeInTheDocument();
-  });
+  ] as const)(
+    'renders image in correct wrapper for %s size',
+    (size, selector) => {
+      setup({ size, image: 'http://example.com/img.png' });
+      expect(document.querySelector(selector)).toBeInTheDocument();
+    }
+  );
 });

--- a/packages/ocean-react/src/Banner/index.ts
+++ b/packages/ocean-react/src/Banner/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Banner';

--- a/packages/ocean-react/src/Banner/stories/Banner.stories.tsx
+++ b/packages/ocean-react/src/Banner/stories/Banner.stories.tsx
@@ -58,11 +58,11 @@ export const Usage: Story = {
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt.',
     image: 'https://placehold.co/800x200',
     primaryAction: {
-      label: 'Ação Primária',
+      label: 'Label',
       onClick: () => console.log('Primary clicked'),
     },
     secondaryAction: {
-      label: 'Ação Secundária',
+      label: 'Label',
       onClick: () => console.log('Secondary clicked'),
     },
   },
@@ -95,11 +95,11 @@ export const WithPrimaryAndSecondaryActions: Story = {
         title="Tipo Default"
         description="Fundo claro com texto escuro — para comunicações gerais."
         primaryAction={{
-          label: 'Ação Primária',
+          label: 'Label',
           onClick: () => console.log('default primary'),
         }}
         secondaryAction={{
-          label: 'Ação Secundária',
+          label: 'Label',
           onClick: () => console.log('default secondary'),
         }}
       />
@@ -109,11 +109,11 @@ export const WithPrimaryAndSecondaryActions: Story = {
         title="Tipo Warning"
         description="Fundo amarelo de atenção — para avisos importantes."
         primaryAction={{
-          label: 'Ação Primária',
+          label: 'Label',
           onClick: () => console.log('warning primary'),
         }}
         secondaryAction={{
-          label: 'Ação Secundária',
+          label: 'Label',
           onClick: () => console.log('warning secondary'),
         }}
       />
@@ -123,11 +123,11 @@ export const WithPrimaryAndSecondaryActions: Story = {
         title="Tipo Negative"
         description="Fundo vermelho suave — para erros ou alertas críticos."
         primaryAction={{
-          label: 'Ação Primária',
+          label: 'Label',
           onClick: () => console.log('negative primary'),
         }}
         secondaryAction={{
-          label: 'Ação Secundária',
+          label: 'Label',
           onClick: () => console.log('negative secondary'),
         }}
       />
@@ -137,11 +137,11 @@ export const WithPrimaryAndSecondaryActions: Story = {
         title="Tipo Emphasys"
         description="Fundo azul primário — para destaques e chamadas de ação importantes."
         primaryAction={{
-          label: 'Ação Primária',
+          label: 'Label',
           onClick: () => console.log('emphasys primary'),
         }}
         secondaryAction={{
-          label: 'Ação Secundária',
+          label: 'Label',
           onClick: () => console.log('emphasys secondary'),
         }}
       />
@@ -169,7 +169,7 @@ export const WithPrimaryActionOnly: Story = {
         title="Tipo Default"
         description="Fundo claro com texto escuro — para comunicações gerais."
         primaryAction={{
-          label: 'Ação Primária',
+          label: 'Label',
           onClick: () => console.log('default primary'),
         }}
       />
@@ -179,7 +179,7 @@ export const WithPrimaryActionOnly: Story = {
         title="Tipo Warning"
         description="Fundo amarelo de atenção — para avisos importantes."
         primaryAction={{
-          label: 'Ação Primária',
+          label: 'Label',
           onClick: () => console.log('warning primary'),
         }}
       />
@@ -189,7 +189,7 @@ export const WithPrimaryActionOnly: Story = {
         title="Tipo Negative"
         description="Fundo vermelho suave — para erros ou alertas críticos."
         primaryAction={{
-          label: 'Ação Primária',
+          label: 'Label',
           onClick: () => console.log('negative primary'),
         }}
       />
@@ -199,7 +199,7 @@ export const WithPrimaryActionOnly: Story = {
         title="Tipo Emphasys"
         description="Fundo azul primário — para destaques e chamadas de ação importantes."
         primaryAction={{
-          label: 'Ação Primária',
+          label: 'Label',
           onClick: () => console.log('emphasys primary'),
         }}
       />
@@ -226,11 +226,11 @@ export const Sizes: Story = {
         description="Imagem no topo (full-width), seguida de título, descrição e botões."
         image="https://placehold.co/800x200"
         primaryAction={{
-          label: 'Ação Primária',
+          label: 'Label',
           onClick: () => console.log('Large primary'),
         }}
         secondaryAction={{
-          label: 'Ação Secundária',
+          label: 'Label',
           onClick: () => console.log('Large secondary'),
         }}
       />
@@ -240,11 +240,11 @@ export const Sizes: Story = {
         description="Imagem à direita (82px), conteúdo à esquerda."
         image="https://placehold.co/200x150"
         primaryAction={{
-          label: 'Ação Primária',
+          label: 'Label',
           onClick: () => console.log('Small primary'),
         }}
         secondaryAction={{
-          label: 'Ação Secundária',
+          label: 'Label',
           onClick: () => console.log('Small secondary'),
         }}
       />
@@ -263,7 +263,7 @@ export const WithoutImage: Story = {
         title="Banner Small sem Imagem"
         description="No tamanho small, a imagem é opcional. Quando omitida, o conteúdo ocupa toda a largura."
         primaryAction={{
-          label: 'Ação Primária',
+          label: 'Label',
           onClick: () => console.log('no image'),
         }}
       />

--- a/packages/ocean-react/src/Banner/stories/Banner.stories.tsx
+++ b/packages/ocean-react/src/Banner/stories/Banner.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof Banner> = {
   argTypes: {
     size: {
       description:
-        'Define o layout do banner. `large` exibe a imagem no topo; `small` exibe a imagem à direita.',
+        'Define o layout do banner. `large` exibe a imagem no topo; `small` exibe a imagem à direita (82px).',
       control: 'select',
       options: ['large', 'small'],
     },
@@ -32,14 +32,14 @@ const meta: Meta<typeof Banner> = {
         'URL da imagem exibida no banner. Quando ausente, a área de imagem não é renderizada.',
       control: 'text',
     },
-    backgroundColor: {
+    primaryAction: {
       description:
-        'Cor de fundo customizada que sobrescreve o padrão do tipo selecionado.',
-      control: 'color',
+        'Ação primária do banner. A variante do botão é derivada automaticamente do `type`.',
+      control: false,
     },
-    buttons: {
+    secondaryAction: {
       description:
-        'Array de botões (máximo 2). Quando vazio ou ausente, nenhum botão é renderizado.',
+        'Ação secundária do banner. A variante do botão é derivada automaticamente do `type`.',
       control: false,
     },
   },
@@ -57,13 +57,11 @@ export const Usage: Story = {
     description:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt.',
     image: 'https://placehold.co/800x200',
-    buttons: [
-      { label: 'Ação Primária', onClick: () => console.log('Primary clicked') },
-      {
-        label: 'Ação Secundária',
-        onClick: () => console.log('Secondary clicked'),
-      },
-    ],
+    primaryAction: { label: 'Ação Primária', onClick: () => console.log('Primary clicked') },
+    secondaryAction: {
+      label: 'Ação Secundária',
+      onClick: () => console.log('Secondary clicked'),
+    },
   },
   decorators: [
     (StoryComponent: React.ComponentType): JSX.Element => (
@@ -87,24 +85,14 @@ export const Sizes: Story = {
         title="Banner Large"
         description="Imagem no topo (full-width), seguida de título, descrição e botões."
         image="https://placehold.co/800x200"
-        buttons={[
-          {
-            label: 'Ação Primária',
-            onClick: () => console.log('Large primary'),
-          },
-        ]}
+        primaryAction={{ label: 'Ação Primária', onClick: () => console.log('Large primary') }}
       />
       <Banner
         size="small"
         title="Banner Small"
-        description="Imagem à direita (25% de largura), conteúdo à esquerda."
+        description="Imagem à direita (82px), conteúdo à esquerda."
         image="https://placehold.co/200x150"
-        buttons={[
-          {
-            label: 'Ação Primária',
-            onClick: () => console.log('Small primary'),
-          },
-        ]}
+        primaryAction={{ label: 'Ação Primária', onClick: () => console.log('Small primary') }}
       />
     </div>
   ),
@@ -119,35 +107,30 @@ export const Types: Story = {
       style={{ display: 'flex', flexDirection: 'column', gap: '24px', maxWidth: '800px' }}
     >
       <Banner
-        size="large"
         type="default"
         title="Tipo Default"
         description="Fundo claro com texto escuro — para comunicações gerais."
-        buttons={[{ label: 'Saiba Mais', onClick: () => console.log('default') }]}
+        primaryAction={{ label: 'Saiba Mais', onClick: () => console.log('default') }}
       />
       <Banner
-        size="large"
         type="warning"
         title="Tipo Warning"
         description="Fundo amarelo de atenção — para avisos importantes."
-        buttons={[{ label: 'Entendi', onClick: () => console.log('warning') }]}
+        primaryAction={{ label: 'Entendi', onClick: () => console.log('warning') }}
+        secondaryAction={{ label: 'Cancelar', onClick: () => console.log('warning secondary') }}
       />
       <Banner
-        size="large"
         type="negative"
         title="Tipo Negative"
         description="Fundo vermelho suave — para erros ou alertas críticos."
-        buttons={[{ label: 'Ver Detalhes', onClick: () => console.log('negative') }]}
+        primaryAction={{ label: 'Ver Detalhes', onClick: () => console.log('negative') }}
       />
       <Banner
-        size="large"
         type="emphasys"
         title="Tipo Emphasys"
         description="Fundo azul primário — para destaques e chamadas de ação importantes."
-        buttons={[
-          { label: 'Começar', onClick: () => console.log('emphasys primary') },
-          { label: 'Saiba Mais', onClick: () => console.log('emphasys secondary') },
-        ]}
+        primaryAction={{ label: 'Começar', onClick: () => console.log('emphasys primary') }}
+        secondaryAction={{ label: 'Saiba Mais', onClick: () => console.log('emphasys secondary') }}
       />
     </div>
   ),
@@ -160,25 +143,23 @@ export const WithoutImage: Story = {
   render: () => (
     <div style={{ maxWidth: '800px' }}>
       <Banner
-        size="large"
         title="Banner sem Imagem"
         description="Quando a prop `image` é omitida, nenhuma área de imagem é renderizada."
-        buttons={[{ label: 'Ação', onClick: () => console.log('no image') }]}
+        primaryAction={{ label: 'Ação', onClick: () => console.log('no image') }}
       />
     </div>
   ),
 };
 
-export const WithoutButtons: Story = {
+export const WithoutActions: Story = {
   parameters: {
     controls: { disable: true },
   },
   render: () => (
     <div style={{ maxWidth: '800px' }}>
       <Banner
-        size="large"
-        title="Banner sem Botões"
-        description="Quando a prop `buttons` é omitida ou vazia, nenhum botão é renderizado."
+        title="Banner sem Ações"
+        description="Quando `primaryAction` e `secondaryAction` são omitidos, nenhum botão é renderizado."
         image="https://placehold.co/800x200"
       />
     </div>

--- a/packages/ocean-react/src/Banner/stories/Banner.stories.tsx
+++ b/packages/ocean-react/src/Banner/stories/Banner.stories.tsx
@@ -1,0 +1,186 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import Banner from '../Banner';
+
+const meta: Meta<typeof Banner> = {
+  title: 'Components/Banner',
+  component: Banner,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      description:
+        'Define o layout do banner. `large` exibe a imagem no topo; `small` exibe a imagem à direita.',
+      control: 'select',
+      options: ['large', 'small'],
+    },
+    type: {
+      description:
+        'Define o tipo visual do banner com cores correspondentes aos tokens do Ocean DS.',
+      control: 'select',
+      options: ['default', 'warning', 'negative', 'emphasys'],
+    },
+    title: {
+      description: 'Título principal exibido no banner.',
+      control: 'text',
+    },
+    description: {
+      description: 'Texto descritivo exibido abaixo do título (opcional).',
+      control: 'text',
+    },
+    image: {
+      description:
+        'URL da imagem exibida no banner. Quando ausente, a área de imagem não é renderizada.',
+      control: 'text',
+    },
+    backgroundColor: {
+      description:
+        'Cor de fundo customizada que sobrescreve o padrão do tipo selecionado.',
+      control: 'color',
+    },
+    buttons: {
+      description:
+        'Array de botões (máximo 2). Quando vazio ou ausente, nenhum botão é renderizado.',
+      control: false,
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Banner>;
+
+export const Usage: Story = {
+  args: {
+    size: 'large',
+    type: 'default',
+    title: 'Título do Banner',
+    description:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt.',
+    image: 'https://placehold.co/800x200',
+    buttons: [
+      { label: 'Ação Primária', onClick: () => console.log('Primary clicked') },
+      {
+        label: 'Ação Secundária',
+        onClick: () => console.log('Secondary clicked'),
+      },
+    ],
+  },
+  decorators: [
+    (StoryComponent: React.ComponentType): JSX.Element => (
+      <div style={{ minWidth: '320px', maxWidth: '800px' }}>
+        <StoryComponent />
+      </div>
+    ),
+  ],
+};
+
+export const Sizes: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <div
+      style={{ display: 'flex', flexDirection: 'column', gap: '24px', maxWidth: '800px' }}
+    >
+      <Banner
+        size="large"
+        title="Banner Large"
+        description="Imagem no topo (full-width), seguida de título, descrição e botões."
+        image="https://placehold.co/800x200"
+        buttons={[
+          {
+            label: 'Ação Primária',
+            onClick: () => console.log('Large primary'),
+          },
+        ]}
+      />
+      <Banner
+        size="small"
+        title="Banner Small"
+        description="Imagem à direita (25% de largura), conteúdo à esquerda."
+        image="https://placehold.co/200x150"
+        buttons={[
+          {
+            label: 'Ação Primária',
+            onClick: () => console.log('Small primary'),
+          },
+        ]}
+      />
+    </div>
+  ),
+};
+
+export const Types: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <div
+      style={{ display: 'flex', flexDirection: 'column', gap: '24px', maxWidth: '800px' }}
+    >
+      <Banner
+        size="large"
+        type="default"
+        title="Tipo Default"
+        description="Fundo claro com texto escuro — para comunicações gerais."
+        buttons={[{ label: 'Saiba Mais', onClick: () => console.log('default') }]}
+      />
+      <Banner
+        size="large"
+        type="warning"
+        title="Tipo Warning"
+        description="Fundo amarelo de atenção — para avisos importantes."
+        buttons={[{ label: 'Entendi', onClick: () => console.log('warning') }]}
+      />
+      <Banner
+        size="large"
+        type="negative"
+        title="Tipo Negative"
+        description="Fundo vermelho suave — para erros ou alertas críticos."
+        buttons={[{ label: 'Ver Detalhes', onClick: () => console.log('negative') }]}
+      />
+      <Banner
+        size="large"
+        type="emphasys"
+        title="Tipo Emphasys"
+        description="Fundo azul primário — para destaques e chamadas de ação importantes."
+        buttons={[
+          { label: 'Começar', onClick: () => console.log('emphasys primary') },
+          { label: 'Saiba Mais', onClick: () => console.log('emphasys secondary') },
+        ]}
+      />
+    </div>
+  ),
+};
+
+export const WithoutImage: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <div style={{ maxWidth: '800px' }}>
+      <Banner
+        size="large"
+        title="Banner sem Imagem"
+        description="Quando a prop `image` é omitida, nenhuma área de imagem é renderizada."
+        buttons={[{ label: 'Ação', onClick: () => console.log('no image') }]}
+      />
+    </div>
+  ),
+};
+
+export const WithoutButtons: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <div style={{ maxWidth: '800px' }}>
+      <Banner
+        size="large"
+        title="Banner sem Botões"
+        description="Quando a prop `buttons` é omitida ou vazia, nenhum botão é renderizado."
+        image="https://placehold.co/800x200"
+      />
+    </div>
+  ),
+};

--- a/packages/ocean-react/src/Banner/stories/Banner.stories.tsx
+++ b/packages/ocean-react/src/Banner/stories/Banner.stories.tsx
@@ -57,7 +57,10 @@ export const Usage: Story = {
     description:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt.',
     image: 'https://placehold.co/800x200',
-    primaryAction: { label: 'Ação Primária', onClick: () => console.log('Primary clicked') },
+    primaryAction: {
+      label: 'Ação Primária',
+      onClick: () => console.log('Primary clicked'),
+    },
     secondaryAction: {
       label: 'Ação Secundária',
       onClick: () => console.log('Secondary clicked'),
@@ -79,35 +82,68 @@ export const WithPrimaryAndSecondaryActions: Story = {
   },
   render: () => (
     <div
-      style={{ display: 'flex', flexDirection: 'column', gap: '24px', maxWidth: '800px' }}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '24px',
+        maxWidth: '800px',
+      }}
     >
       <Banner
+        size="small"
         type="default"
         title="Tipo Default"
         description="Fundo claro com texto escuro — para comunicações gerais."
-        primaryAction={{ label: 'Ação Primária', onClick: () => console.log('default primary') }}
-        secondaryAction={{ label: 'Ação Secundária', onClick: () => console.log('default secondary') }}
+        primaryAction={{
+          label: 'Ação Primária',
+          onClick: () => console.log('default primary'),
+        }}
+        secondaryAction={{
+          label: 'Ação Secundária',
+          onClick: () => console.log('default secondary'),
+        }}
       />
       <Banner
+        size="small"
         type="warning"
         title="Tipo Warning"
         description="Fundo amarelo de atenção — para avisos importantes."
-        primaryAction={{ label: 'Ação Primária', onClick: () => console.log('warning primary') }}
-        secondaryAction={{ label: 'Ação Secundária', onClick: () => console.log('warning secondary') }}
+        primaryAction={{
+          label: 'Ação Primária',
+          onClick: () => console.log('warning primary'),
+        }}
+        secondaryAction={{
+          label: 'Ação Secundária',
+          onClick: () => console.log('warning secondary'),
+        }}
       />
       <Banner
+        size="small"
         type="negative"
         title="Tipo Negative"
         description="Fundo vermelho suave — para erros ou alertas críticos."
-        primaryAction={{ label: 'Ação Primária', onClick: () => console.log('negative primary') }}
-        secondaryAction={{ label: 'Ação Secundária', onClick: () => console.log('negative secondary') }}
+        primaryAction={{
+          label: 'Ação Primária',
+          onClick: () => console.log('negative primary'),
+        }}
+        secondaryAction={{
+          label: 'Ação Secundária',
+          onClick: () => console.log('negative secondary'),
+        }}
       />
       <Banner
+        size="small"
         type="emphasys"
         title="Tipo Emphasys"
         description="Fundo azul primário — para destaques e chamadas de ação importantes."
-        primaryAction={{ label: 'Ação Primária', onClick: () => console.log('emphasys primary') }}
-        secondaryAction={{ label: 'Ação Secundária', onClick: () => console.log('emphasys secondary') }}
+        primaryAction={{
+          label: 'Ação Primária',
+          onClick: () => console.log('emphasys primary'),
+        }}
+        secondaryAction={{
+          label: 'Ação Secundária',
+          onClick: () => console.log('emphasys secondary'),
+        }}
       />
     </div>
   ),
@@ -120,31 +156,52 @@ export const WithPrimaryActionOnly: Story = {
   },
   render: () => (
     <div
-      style={{ display: 'flex', flexDirection: 'column', gap: '24px', maxWidth: '800px' }}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '24px',
+        maxWidth: '800px',
+      }}
     >
       <Banner
+        size="small"
         type="default"
         title="Tipo Default"
         description="Fundo claro com texto escuro — para comunicações gerais."
-        primaryAction={{ label: 'Ação Primária', onClick: () => console.log('default primary') }}
+        primaryAction={{
+          label: 'Ação Primária',
+          onClick: () => console.log('default primary'),
+        }}
       />
       <Banner
+        size="small"
         type="warning"
         title="Tipo Warning"
         description="Fundo amarelo de atenção — para avisos importantes."
-        primaryAction={{ label: 'Ação Primária', onClick: () => console.log('warning primary') }}
+        primaryAction={{
+          label: 'Ação Primária',
+          onClick: () => console.log('warning primary'),
+        }}
       />
       <Banner
+        size="small"
         type="negative"
         title="Tipo Negative"
         description="Fundo vermelho suave — para erros ou alertas críticos."
-        primaryAction={{ label: 'Ação Primária', onClick: () => console.log('negative primary') }}
+        primaryAction={{
+          label: 'Ação Primária',
+          onClick: () => console.log('negative primary'),
+        }}
       />
       <Banner
+        size="small"
         type="emphasys"
         title="Tipo Emphasys"
         description="Fundo azul primário — para destaques e chamadas de ação importantes."
-        primaryAction={{ label: 'Ação Primária', onClick: () => console.log('emphasys primary') }}
+        primaryAction={{
+          label: 'Ação Primária',
+          onClick: () => console.log('emphasys primary'),
+        }}
       />
     </div>
   ),
@@ -156,23 +213,40 @@ export const Sizes: Story = {
   },
   render: () => (
     <div
-      style={{ display: 'flex', flexDirection: 'column', gap: '24px', maxWidth: '800px' }}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '24px',
+        maxWidth: '800px',
+      }}
     >
       <Banner
         size="large"
         title="Banner Large"
         description="Imagem no topo (full-width), seguida de título, descrição e botões."
         image="https://placehold.co/800x200"
-        primaryAction={{ label: 'Ação Primária', onClick: () => console.log('Large primary') }}
-        secondaryAction={{ label: 'Ação Secundária', onClick: () => console.log('Large secondary') }}
+        primaryAction={{
+          label: 'Ação Primária',
+          onClick: () => console.log('Large primary'),
+        }}
+        secondaryAction={{
+          label: 'Ação Secundária',
+          onClick: () => console.log('Large secondary'),
+        }}
       />
       <Banner
         size="small"
         title="Banner Small"
         description="Imagem à direita (82px), conteúdo à esquerda."
         image="https://placehold.co/200x150"
-        primaryAction={{ label: 'Ação Primária', onClick: () => console.log('Small primary') }}
-        secondaryAction={{ label: 'Ação Secundária', onClick: () => console.log('Small secondary') }}
+        primaryAction={{
+          label: 'Ação Primária',
+          onClick: () => console.log('Small primary'),
+        }}
+        secondaryAction={{
+          label: 'Ação Secundária',
+          onClick: () => console.log('Small secondary'),
+        }}
       />
     </div>
   ),
@@ -185,9 +259,13 @@ export const WithoutImage: Story = {
   render: () => (
     <div style={{ maxWidth: '800px' }}>
       <Banner
-        title="Banner sem Imagem"
-        description="Quando a prop `image` é omitida, nenhuma área de imagem é renderizada."
-        primaryAction={{ label: 'Ação Primária', onClick: () => console.log('no image') }}
+        size="small"
+        title="Banner Small sem Imagem"
+        description="No tamanho small, a imagem é opcional. Quando omitida, o conteúdo ocupa toda a largura."
+        primaryAction={{
+          label: 'Ação Primária',
+          onClick: () => console.log('no image'),
+        }}
       />
     </div>
   ),

--- a/packages/ocean-react/src/Banner/stories/Banner.stories.tsx
+++ b/packages/ocean-react/src/Banner/stories/Banner.stories.tsx
@@ -72,6 +72,84 @@ export const Usage: Story = {
   ],
 };
 
+export const WithPrimaryAndSecondaryActions: Story = {
+  name: 'With Primary & Secondary Actions',
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <div
+      style={{ display: 'flex', flexDirection: 'column', gap: '24px', maxWidth: '800px' }}
+    >
+      <Banner
+        type="default"
+        title="Tipo Default"
+        description="Fundo claro com texto escuro — para comunicações gerais."
+        primaryAction={{ label: 'Ação Primária', onClick: () => console.log('default primary') }}
+        secondaryAction={{ label: 'Ação Secundária', onClick: () => console.log('default secondary') }}
+      />
+      <Banner
+        type="warning"
+        title="Tipo Warning"
+        description="Fundo amarelo de atenção — para avisos importantes."
+        primaryAction={{ label: 'Ação Primária', onClick: () => console.log('warning primary') }}
+        secondaryAction={{ label: 'Ação Secundária', onClick: () => console.log('warning secondary') }}
+      />
+      <Banner
+        type="negative"
+        title="Tipo Negative"
+        description="Fundo vermelho suave — para erros ou alertas críticos."
+        primaryAction={{ label: 'Ação Primária', onClick: () => console.log('negative primary') }}
+        secondaryAction={{ label: 'Ação Secundária', onClick: () => console.log('negative secondary') }}
+      />
+      <Banner
+        type="emphasys"
+        title="Tipo Emphasys"
+        description="Fundo azul primário — para destaques e chamadas de ação importantes."
+        primaryAction={{ label: 'Ação Primária', onClick: () => console.log('emphasys primary') }}
+        secondaryAction={{ label: 'Ação Secundária', onClick: () => console.log('emphasys secondary') }}
+      />
+    </div>
+  ),
+};
+
+export const WithPrimaryActionOnly: Story = {
+  name: 'With Primary Action Only',
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <div
+      style={{ display: 'flex', flexDirection: 'column', gap: '24px', maxWidth: '800px' }}
+    >
+      <Banner
+        type="default"
+        title="Tipo Default"
+        description="Fundo claro com texto escuro — para comunicações gerais."
+        primaryAction={{ label: 'Ação Primária', onClick: () => console.log('default primary') }}
+      />
+      <Banner
+        type="warning"
+        title="Tipo Warning"
+        description="Fundo amarelo de atenção — para avisos importantes."
+        primaryAction={{ label: 'Ação Primária', onClick: () => console.log('warning primary') }}
+      />
+      <Banner
+        type="negative"
+        title="Tipo Negative"
+        description="Fundo vermelho suave — para erros ou alertas críticos."
+        primaryAction={{ label: 'Ação Primária', onClick: () => console.log('negative primary') }}
+      />
+      <Banner
+        type="emphasys"
+        title="Tipo Emphasys"
+        description="Fundo azul primário — para destaques e chamadas de ação importantes."
+        primaryAction={{ label: 'Ação Primária', onClick: () => console.log('emphasys primary') }}
+      />
+    </div>
+  ),
+};
+
 export const Sizes: Story = {
   parameters: {
     controls: { disable: true },
@@ -86,6 +164,7 @@ export const Sizes: Story = {
         description="Imagem no topo (full-width), seguida de título, descrição e botões."
         image="https://placehold.co/800x200"
         primaryAction={{ label: 'Ação Primária', onClick: () => console.log('Large primary') }}
+        secondaryAction={{ label: 'Ação Secundária', onClick: () => console.log('Large secondary') }}
       />
       <Banner
         size="small"
@@ -93,44 +172,7 @@ export const Sizes: Story = {
         description="Imagem à direita (82px), conteúdo à esquerda."
         image="https://placehold.co/200x150"
         primaryAction={{ label: 'Ação Primária', onClick: () => console.log('Small primary') }}
-      />
-    </div>
-  ),
-};
-
-export const Types: Story = {
-  parameters: {
-    controls: { disable: true },
-  },
-  render: () => (
-    <div
-      style={{ display: 'flex', flexDirection: 'column', gap: '24px', maxWidth: '800px' }}
-    >
-      <Banner
-        type="default"
-        title="Tipo Default"
-        description="Fundo claro com texto escuro — para comunicações gerais."
-        primaryAction={{ label: 'Saiba Mais', onClick: () => console.log('default') }}
-      />
-      <Banner
-        type="warning"
-        title="Tipo Warning"
-        description="Fundo amarelo de atenção — para avisos importantes."
-        primaryAction={{ label: 'Entendi', onClick: () => console.log('warning') }}
-        secondaryAction={{ label: 'Cancelar', onClick: () => console.log('warning secondary') }}
-      />
-      <Banner
-        type="negative"
-        title="Tipo Negative"
-        description="Fundo vermelho suave — para erros ou alertas críticos."
-        primaryAction={{ label: 'Ver Detalhes', onClick: () => console.log('negative') }}
-      />
-      <Banner
-        type="emphasys"
-        title="Tipo Emphasys"
-        description="Fundo azul primário — para destaques e chamadas de ação importantes."
-        primaryAction={{ label: 'Começar', onClick: () => console.log('emphasys primary') }}
-        secondaryAction={{ label: 'Saiba Mais', onClick: () => console.log('emphasys secondary') }}
+        secondaryAction={{ label: 'Ação Secundária', onClick: () => console.log('Small secondary') }}
       />
     </div>
   ),
@@ -145,7 +187,7 @@ export const WithoutImage: Story = {
       <Banner
         title="Banner sem Imagem"
         description="Quando a prop `image` é omitida, nenhuma área de imagem é renderizada."
-        primaryAction={{ label: 'Ação', onClick: () => console.log('no image') }}
+        primaryAction={{ label: 'Ação Primária', onClick: () => console.log('no image') }}
       />
     </div>
   ),

--- a/packages/ocean-react/src/index.ts
+++ b/packages/ocean-react/src/index.ts
@@ -95,6 +95,9 @@ export * from './Steps';
 export { default as Badge } from './Badge';
 export * from './Badge';
 
+export { default as Banner } from './Banner';
+export * from './Banner';
+
 export { default as CrossSellCard } from './CrossSellCard';
 export * from './CrossSellCard';
 


### PR DESCRIPTION
## Descrição

Implementa o componente Banner no Ocean Design System Web, conforme especificação do PRD [#1247](https://github.com/ocean-ds/ocean-web/issues/1247) e Jira [MR-494](https://useblu.atlassian.net/browse/MR-494).

## Mudanças

- Novo componente `Banner` em `packages/ocean-react`
- Estilos BEM em `packages/ocean-core`
- Stories no Storybook com todas as variantes
- Testes unitários com cobertura de todos os comportamentos
- Documentação em `packages/ocean-docs`

## Variantes implementadas

- **Size:** `large` (imagem no topo), `small` (imagem à direita)
- **Type:** `default`, `warning`, `negative`, `emphasys`
- **Props opcionais:** `description`, `image`, `buttons` (array, máx 2), `backgroundColor`

## Jira

MR-494