### PR TITLE
feat: add TransactionFooter component with default and highlight variants

### DIFF
--- a/packages/ocean-core/src/components/_all.scss
+++ b/packages/ocean-core/src/components/_all.scss
@@ -45,3 +45,4 @@
 @import 'corner-tag';
 @import 'internal-contextual-hero';
 @import 'contextual-menu';
+@import 'transaction-footer';

--- a/packages/ocean-core/src/components/_transaction-footer.scss
+++ b/packages/ocean-core/src/components/_transaction-footer.scss
@@ -1,6 +1,21 @@
 .ods-transaction-footer {
   background-color: $color-interface-light-pure;
-  padding: $spacing-inset-sm;
+  display: flex;
+  flex-direction: column;
+  padding-top: $spacing-stack-xxs;
+  position: relative;
+
+  // Divisor de topo da variante Default — desenhado dentro do espaçador de 8px
+  // (`padding-top`), sem adicionar altura, então alternar variante não gera "pulo".
+  &--default::before {
+    background-color: $color-interface-light-down;
+    content: '';
+    height: $border-width-hairline;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
 
   &--highlight {
     background-color: $color-interface-light-up;

--- a/packages/ocean-core/src/components/_transaction-footer.scss
+++ b/packages/ocean-core/src/components/_transaction-footer.scss
@@ -1,0 +1,10 @@
+.ods-transaction-footer {
+  background-color: $color-interface-light-pure;
+  padding: $spacing-inset-sm;
+
+  &--highlight {
+    background-color: $color-interface-light-up;
+    border-top-left-radius: $border-radius-lg;
+    border-top-right-radius: $border-radius-lg;
+  }
+}

--- a/packages/ocean-docs/docs/components/transactionfooter.mdx
+++ b/packages/ocean-docs/docs/components/transactionfooter.mdx
@@ -12,7 +12,7 @@ import StorybookEmbed from '@site/src/components/StorybookEmbed';
 
 # TransactionFooter
 
-O `TransactionFooter` é o rodapé de resumo financeiro de telas de pagamento: agrupa as linhas de benefício → custo → total, um divisor e os botões de ação em um único bloco visual. Ele recebe o conteúdo como `children` (composição livre pelo consumidor) e expõe apenas a variante visual.
+O `TransactionFooter` é o rodapé de resumo financeiro de telas de pagamento: agrupa as linhas de resumo, um divisor e os botões de ação em um único bloco visual. Ele recebe o conteúdo como `children` (composição livre pelo consumidor) e expõe apenas a variante visual.
 
 A estrutura interna segue o Figma do Ocean DS Core: um **Section Header** opcional, linhas de resumo (label à esquerda em `colorInterfaceDarkDown`, valor à direita em `colorInterfaceDarkDeep`, `paragraph` 16px), um **Divider** interno e uma **Button Bar** com o botão primário. As linhas usam `padding` de `8px 16px` e a Button Bar `16px`.
 
@@ -61,7 +61,7 @@ Fundo `colorInterfaceLightPure`, cantos retos e um **divisor no topo** (`colorIn
 <TransactionFooter variant="default">
   <div style={{ padding: '8px 16px 4px' }}>
     <Typography variant="heading5">
-      <span style={{ color: '#AAADC0' }}>Resumo</span>
+      <span style={{ color: '#AAADC0' }}>Title</span>
     </Typography>
   </div>
   <div
@@ -73,13 +73,13 @@ Fundo `colorInterfaceLightPure`, cantos retos e um **divisor no topo** (`colorIn
     }}
   >
     <Typography variant="paragraph" style={{ flex: '1 0 0' }}>
-      <span style={{ color: '#67697A' }}>Você vai economizar</span>
+      <span style={{ color: '#67697A' }}>Title</span>
     </Typography>
     <Typography
       variant="paragraph"
       style={{ flex: '1 0 0', textAlign: 'right' }}
     >
-      R$ 3.574,28
+      Description
     </Typography>
   </div>
   <div style={{ padding: '12px 16px' }}>
@@ -94,18 +94,18 @@ Fundo `colorInterfaceLightPure`, cantos retos e um **divisor no topo** (`colorIn
     }}
   >
     <Typography variant="paragraph" style={{ flex: '1 0 0' }}>
-      <span style={{ color: '#67697A' }}>Total</span>
+      <span style={{ color: '#67697A' }}>Title</span>
     </Typography>
     <Typography
       variant="paragraph"
       style={{ flex: '1 0 0', textAlign: 'right' }}
     >
-      R$ 42.314,10
+      Description
     </Typography>
   </div>
   <div style={{ padding: 16 }}>
     <Button variant="primary" blocked>
-      Continuar
+      Label
     </Button>
   </div>
 </TransactionFooter>
@@ -126,13 +126,13 @@ Fundo `colorInterfaceLightUp` com cantos superiores arredondados (16px) e **sem*
     }}
   >
     <Typography variant="paragraph" style={{ flex: '1 0 0' }}>
-      <span style={{ color: '#67697A' }}>Desconto</span>
+      <span style={{ color: '#67697A' }}>Title</span>
     </Typography>
     <Typography
       variant="paragraph"
       style={{ flex: '1 0 0', textAlign: 'right' }}
     >
-      -R$ 1.057,85
+      Description
     </Typography>
   </div>
   <div
@@ -144,18 +144,18 @@ Fundo `colorInterfaceLightUp` com cantos superiores arredondados (16px) e **sem*
     }}
   >
     <Typography variant="paragraph" style={{ flex: '1 0 0' }}>
-      <span style={{ color: '#67697A' }}>Pagando</span>
+      <span style={{ color: '#67697A' }}>Title</span>
     </Typography>
     <Typography
       variant="paragraph"
       style={{ flex: '1 0 0', textAlign: 'right' }}
     >
-      R$ 41.256,25
+      Description
     </Typography>
   </div>
   <div style={{ padding: 16 }}>
     <Button variant="primary" blocked>
-      Confirmar pagamento
+      Label
     </Button>
   </div>
 </TransactionFooter>

--- a/packages/ocean-docs/docs/components/transactionfooter.mdx
+++ b/packages/ocean-docs/docs/components/transactionfooter.mdx
@@ -1,0 +1,169 @@
+---
+title: TransactionFooter
+---
+
+import {
+  TransactionFooter,
+  Typography,
+  Divider,
+  Button,
+} from '@useblu/ocean-react';
+import StorybookEmbed from '@site/src/components/StorybookEmbed';
+
+# TransactionFooter
+
+O `TransactionFooter` é o rodapé de resumo financeiro de telas de pagamento: agrupa as linhas de benefício → custo → total, um divisor e os botões de ação em um único bloco visual. Ele recebe o conteúdo como `children` (composição livre pelo consumidor) e expõe apenas a variante visual.
+
+## Importação
+
+```tsx
+import { TransactionFooter } from '@useblu/ocean-react';
+```
+
+### Importação específica (recomendado para tree-shaking)
+
+```tsx
+import { TransactionFooter } from '@useblu/ocean-react/TransactionFooter';
+```
+
+### Importação de tipos TypeScript
+
+```tsx
+import type {
+  TransactionFooterProps,
+  TransactionFooterVariant,
+} from '@useblu/ocean-react';
+```
+
+## Playground Interativo
+
+Explore o componente `TransactionFooter` no playground interativo do Storybook:
+
+<StorybookEmbed
+  storyId="components-transactionfooter--usage"
+  height={520}
+  title="TransactionFooter - Playground Interativo"
+/>
+
+## Documentação Completa
+
+Para documentação técnica detalhada, exemplos de uso e API completa, consulte o **[Storybook do TransactionFooter](https://ocean-ds.github.io/ocean-web/?path=/docs/components-transactionfooter--docs)**.
+
+## Uso básico
+
+### Variante `default`
+
+Fundo neutro (`colorInterfaceLightPure`) com cantos retos — é o valor inicial da prop `variant`.
+
+```tsx live
+<TransactionFooter variant="default">
+  <div
+    style={{
+      display: 'flex',
+      justifyContent: 'space-between',
+      marginBottom: 8,
+    }}
+  >
+    <Typography variant="paragraph">Total</Typography>
+    <Typography variant="paragraph">
+      <strong>R$ 42.314,10</strong>
+    </Typography>
+  </div>
+  <Button variant="primary" blocked>
+    Continuar
+  </Button>
+</TransactionFooter>
+```
+
+### Variante `highlight`
+
+Fundo `colorInterfaceLightUp` com cantos superiores arredondados (16px). As dimensões externas do bloco são idênticas às da `default` — alternar a variante não causa "pulo" de layout.
+
+```tsx live
+<TransactionFooter variant="highlight">
+  <div
+    style={{
+      display: 'flex',
+      justifyContent: 'space-between',
+      marginBottom: 8,
+    }}
+  >
+    <Typography variant="paragraph">Você vai economizar</Typography>
+    <Typography variant="paragraph">R$ 3.574,28</Typography>
+  </div>
+  <Divider style={{ marginTop: 8, marginBottom: 8 }} />
+  <div
+    style={{
+      display: 'flex',
+      justifyContent: 'space-between',
+      marginBottom: 16,
+    }}
+  >
+    <Typography variant="paragraph">Pagando</Typography>
+    <Typography variant="paragraph">
+      <strong>R$ 41.256,25</strong>
+    </Typography>
+  </div>
+  <Button variant="primary" blocked>
+    Confirmar pagamento
+  </Button>
+</TransactionFooter>
+```
+
+## API
+
+### Props
+
+| Prop        | Tipo                       | Padrão      | Descrição                                                                                                                        |
+| ----------- | -------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `variant`   | `'default' \| 'highlight'` | `'default'` | Variante visual. `default` = fundo neutro e cantos retos; `highlight` = fundo destacado e cantos superiores arredondados (16px). |
+| `children`  | `ReactNode`                | -           | Conteúdo do rodapé (linhas de resumo, divisor e botões), composto pelo consumidor.                                               |
+| `className` | `string`                   | -           | Classes CSS adicionais.                                                                                                          |
+
+O componente também repassa (`...rest`) qualquer atributo válido de uma `<div>` (por exemplo `id`, `aria-*`, `data-*`, `style`).
+
+## Acessibilidade
+
+- ✅ É renderizado como um `<div>` neutro — a semântica do conteúdo (linhas, botões) é responsabilidade da composição interna.
+- ✅ O contraste dos textos sobre o fundo `colorInterfaceLightUp` (variante `highlight`) atende ao WCAG AA.
+- ✅ Aceita atributos `aria-*` via `...rest` quando o bloco precisa de um rótulo próprio.
+
+## Melhores práticas
+
+### ✅ Faça
+
+- Mantenha a **linha de benefício em primeiro** e o **total como última linha**, em negrito.
+- Coloque o **botão dentro do footer**, usando `Button` com `variant="primary"` e `blocked`.
+- Use `highlight` quando o rodapé precisa se destacar do conteúdo rolável acima (ex.: card fixo na base).
+
+### ❌ Não faça
+
+- Não recrie o container com `styled-components` ou `<div>` cru quando o `TransactionFooter` já resolve fundo, padding e cantos.
+- Não coloque custos técnicos (IOF, juros, CET) como linha — eles pertencem a um drawer de detalhes.
+- Não altere padding/dimensões para "compensar" a variante — as duas variantes têm a mesma caixa externa.
+
+## Quando Usar
+
+### ✅ Ideal para:
+
+- Telas de **seleção de método de pagamento** e **revisão de pagamento**, resumindo o impacto financeiro antes da ação principal.
+
+### ❌ Evite para:
+
+- Listagens onde o toque em cada item já navega (use `TransactionListItem` com chevron).
+- Exibir a cobrança principal (essa vai no cabeçalho da tela, não no rodapé).
+
+## CSS Classes
+
+| Classe                               | Descrição                                                |
+| ------------------------------------ | -------------------------------------------------------- |
+| `.ods-transaction-footer`            | Classe base aplicada ao container do rodapé.             |
+| `.ods-transaction-footer--default`   | Modificador da variante padrão (fundo neutro).           |
+| `.ods-transaction-footer--highlight` | Modificador da variante destacada (fundo + cantos 16px). |
+
+## Links relacionados
+
+- [TransactionListItem](/components/transactionlistitem) - Para itens de lista de transações.
+- [Button](/components/button) - Botão de ação usado dentro do rodapé.
+- [Divider](/components/divider) - Divisor entre as linhas do resumo.
+- [Storybook - TransactionFooter](https://ocean-ds.github.io/ocean-web/?path=/docs/components-transactionfooter--docs) - Documentação técnica.

--- a/packages/ocean-docs/docs/components/transactionfooter.mdx
+++ b/packages/ocean-docs/docs/components/transactionfooter.mdx
@@ -14,6 +14,8 @@ import StorybookEmbed from '@site/src/components/StorybookEmbed';
 
 O `TransactionFooter` é o rodapé de resumo financeiro de telas de pagamento: agrupa as linhas de benefício → custo → total, um divisor e os botões de ação em um único bloco visual. Ele recebe o conteúdo como `children` (composição livre pelo consumidor) e expõe apenas a variante visual.
 
+A estrutura interna segue o Figma do Ocean DS Core: um **Section Header** opcional, linhas de resumo (label à esquerda em `colorInterfaceDarkDown`, valor à direita em `colorInterfaceDarkDeep`, `paragraph` 16px), um **Divider** interno e uma **Button Bar** com o botão primário. As linhas usam `padding` de `8px 16px` e a Button Bar `16px`.
+
 ## Importação
 
 ```tsx
@@ -53,60 +55,109 @@ Para documentação técnica detalhada, exemplos de uso e API completa, consulte
 
 ### Variante `default`
 
-Fundo neutro (`colorInterfaceLightPure`) com cantos retos — é o valor inicial da prop `variant`.
+Fundo `colorInterfaceLightPure`, cantos retos e um **divisor no topo** (`colorInterfaceLightDown`). É o valor inicial da prop `variant`.
 
 ```tsx live
 <TransactionFooter variant="default">
+  <div style={{ padding: '8px 16px 4px' }}>
+    <Typography variant="heading5">
+      <span style={{ color: '#AAADC0' }}>Resumo</span>
+    </Typography>
+  </div>
   <div
     style={{
       display: 'flex',
-      justifyContent: 'space-between',
-      marginBottom: 8,
+      alignItems: 'center',
+      gap: 8,
+      padding: '8px 16px',
     }}
   >
-    <Typography variant="paragraph">Total</Typography>
-    <Typography variant="paragraph">
-      <strong>R$ 42.314,10</strong>
+    <Typography variant="paragraph" style={{ flex: '1 0 0' }}>
+      <span style={{ color: '#67697A' }}>Você vai economizar</span>
+    </Typography>
+    <Typography
+      variant="paragraph"
+      style={{ flex: '1 0 0', textAlign: 'right' }}
+    >
+      R$ 3.574,28
     </Typography>
   </div>
-  <Button variant="primary" blocked>
-    Continuar
-  </Button>
+  <div style={{ padding: '12px 16px' }}>
+    <Divider />
+  </div>
+  <div
+    style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 8,
+      padding: '8px 16px',
+    }}
+  >
+    <Typography variant="paragraph" style={{ flex: '1 0 0' }}>
+      <span style={{ color: '#67697A' }}>Total</span>
+    </Typography>
+    <Typography
+      variant="paragraph"
+      style={{ flex: '1 0 0', textAlign: 'right' }}
+    >
+      R$ 42.314,10
+    </Typography>
+  </div>
+  <div style={{ padding: 16 }}>
+    <Button variant="primary" blocked>
+      Continuar
+    </Button>
+  </div>
 </TransactionFooter>
 ```
 
 ### Variante `highlight`
 
-Fundo `colorInterfaceLightUp` com cantos superiores arredondados (16px). As dimensões externas do bloco são idênticas às da `default` — alternar a variante não causa "pulo" de layout.
+Fundo `colorInterfaceLightUp` com cantos superiores arredondados (16px) e **sem** divisor no topo. As dimensões externas do bloco são idênticas às da `default` — alternar a variante não causa "pulo" de layout.
 
 ```tsx live
 <TransactionFooter variant="highlight">
   <div
     style={{
       display: 'flex',
-      justifyContent: 'space-between',
-      marginBottom: 8,
+      alignItems: 'center',
+      gap: 8,
+      padding: '8px 16px',
     }}
   >
-    <Typography variant="paragraph">Você vai economizar</Typography>
-    <Typography variant="paragraph">R$ 3.574,28</Typography>
+    <Typography variant="paragraph" style={{ flex: '1 0 0' }}>
+      <span style={{ color: '#67697A' }}>Desconto</span>
+    </Typography>
+    <Typography
+      variant="paragraph"
+      style={{ flex: '1 0 0', textAlign: 'right' }}
+    >
+      -R$ 1.057,85
+    </Typography>
   </div>
-  <Divider style={{ marginTop: 8, marginBottom: 8 }} />
   <div
     style={{
       display: 'flex',
-      justifyContent: 'space-between',
-      marginBottom: 16,
+      alignItems: 'center',
+      gap: 8,
+      padding: '8px 16px',
     }}
   >
-    <Typography variant="paragraph">Pagando</Typography>
-    <Typography variant="paragraph">
-      <strong>R$ 41.256,25</strong>
+    <Typography variant="paragraph" style={{ flex: '1 0 0' }}>
+      <span style={{ color: '#67697A' }}>Pagando</span>
+    </Typography>
+    <Typography
+      variant="paragraph"
+      style={{ flex: '1 0 0', textAlign: 'right' }}
+    >
+      R$ 41.256,25
     </Typography>
   </div>
-  <Button variant="primary" blocked>
-    Confirmar pagamento
-  </Button>
+  <div style={{ padding: 16 }}>
+    <Button variant="primary" blocked>
+      Confirmar pagamento
+    </Button>
+  </div>
 </TransactionFooter>
 ```
 
@@ -114,13 +165,26 @@ Fundo `colorInterfaceLightUp` com cantos superiores arredondados (16px). As dime
 
 ### Props
 
-| Prop        | Tipo                       | Padrão      | Descrição                                                                                                                        |
-| ----------- | -------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `variant`   | `'default' \| 'highlight'` | `'default'` | Variante visual. `default` = fundo neutro e cantos retos; `highlight` = fundo destacado e cantos superiores arredondados (16px). |
-| `children`  | `ReactNode`                | -           | Conteúdo do rodapé (linhas de resumo, divisor e botões), composto pelo consumidor.                                               |
-| `className` | `string`                   | -           | Classes CSS adicionais.                                                                                                          |
+| Prop        | Tipo                       | Padrão      | Descrição                                                                                                                                         |
+| ----------- | -------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `variant`   | `'default' \| 'highlight'` | `'default'` | Variante visual. `default` = fundo neutro, cantos retos e divisor no topo; `highlight` = fundo destacado e cantos superiores arredondados (16px). |
+| `children`  | `ReactNode`                | -           | Conteúdo do rodapé (Section Header, linhas de resumo, Divider e Button Bar), composto pelo consumidor.                                            |
+| `className` | `string`                   | -           | Classes CSS adicionais.                                                                                                                           |
 
 O componente também repassa (`...rest`) qualquer atributo válido de uma `<div>` (por exemplo `id`, `aria-*`, `data-*`, `style`).
+
+## Tokens usados
+
+| Elemento           | Token                                            | Valor                              |
+| ------------------ | ------------------------------------------------ | ---------------------------------- |
+| Fundo `default`    | `colorInterfaceLightPure`                        | `#FFFFFF`                          |
+| Fundo `highlight`  | `colorInterfaceLightUp`                          | `#F3F5FE`                          |
+| Divisores          | `colorInterfaceLightDown`                        | `#E0E2EE`                          |
+| Cantos `highlight` | `borderRadiusLg`                                 | `16px`                             |
+| Section Header     | `heading5` / `colorInterfaceDarkUp`              | Nunito Sans Bold 14 / `#AAADC0`    |
+| Label da linha     | `paragraph` / `colorInterfaceDarkDown`           | Nunito Sans Regular 16 / `#67697A` |
+| Valor da linha     | `paragraph` / `colorInterfaceDarkDeep`           | Nunito Sans Regular 16 / `#393B47` |
+| Botão primário     | `colorBrandPrimaryPure` / `borderRadiusCircular` | `#0025E0` / pill                   |
 
 ## Acessibilidade
 
@@ -132,13 +196,13 @@ O componente também repassa (`...rest`) qualquer atributo válido de uma `<div>
 
 ### ✅ Faça
 
-- Mantenha a **linha de benefício em primeiro** e o **total como última linha**, em negrito.
+- Mantenha a **linha de benefício em primeiro** e o **total como última linha**.
 - Coloque o **botão dentro do footer**, usando `Button` com `variant="primary"` e `blocked`.
 - Use `highlight` quando o rodapé precisa se destacar do conteúdo rolável acima (ex.: card fixo na base).
 
 ### ❌ Não faça
 
-- Não recrie o container com `styled-components` ou `<div>` cru quando o `TransactionFooter` já resolve fundo, padding e cantos.
+- Não recrie o container com `styled-components` ou `<div>` cru quando o `TransactionFooter` já resolve fundo, padding de topo, divisor e cantos.
 - Não coloque custos técnicos (IOF, juros, CET) como linha — eles pertencem a um drawer de detalhes.
 - Não altere padding/dimensões para "compensar" a variante — as duas variantes têm a mesma caixa externa.
 
@@ -155,11 +219,11 @@ O componente também repassa (`...rest`) qualquer atributo válido de uma `<div>
 
 ## CSS Classes
 
-| Classe                               | Descrição                                                |
-| ------------------------------------ | -------------------------------------------------------- |
-| `.ods-transaction-footer`            | Classe base aplicada ao container do rodapé.             |
-| `.ods-transaction-footer--default`   | Modificador da variante padrão (fundo neutro).           |
-| `.ods-transaction-footer--highlight` | Modificador da variante destacada (fundo + cantos 16px). |
+| Classe                               | Descrição                                                       |
+| ------------------------------------ | --------------------------------------------------------------- |
+| `.ods-transaction-footer`            | Classe base do container (fundo, espaçador de topo de 8px).     |
+| `.ods-transaction-footer--default`   | Variante padrão — fundo neutro + divisor no topo (`::before`).  |
+| `.ods-transaction-footer--highlight` | Variante destacada — fundo `light-up` + cantos superiores 16px. |
 
 ## Links relacionados
 

--- a/packages/ocean-docs/sidebars.ts
+++ b/packages/ocean-docs/sidebars.ts
@@ -75,6 +75,7 @@ const sidebars: SidebarsConfig = {
         'components/topbar',
         'components/transactionlistitem',
         'components/transactionlistexpandable',
+        'components/transactionfooter',
         'components/typography',
         'components/unordered-list-item',
         'components/webnotification',

--- a/packages/ocean-react/src/TransactionFooter/TransactionFooter.tsx
+++ b/packages/ocean-react/src/TransactionFooter/TransactionFooter.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import classNames from 'classnames';
+
+export type TransactionFooterVariant = 'default' | 'highlight';
+
+export type TransactionFooterProps = {
+  /**
+   * A variante visual do rodapé.
+   * `default` mantém o fundo neutro (`colorInterfaceLightPure`) com cantos retos;
+   * `highlight` aplica o fundo `colorInterfaceLightUp` e arredonda os cantos
+   * superiores em 16px, sem alterar as dimensões externas do bloco.
+   * @default 'default'
+   */
+  variant?: TransactionFooterVariant;
+  /**
+   * O conteúdo do rodapé — linhas de resumo (benefício → custo → total), divisor
+   * e botões. A composição e a ordem das linhas são responsabilidade do consumidor.
+   */
+  children: React.ReactNode;
+} & React.ComponentPropsWithoutRef<'div'>;
+
+const TransactionFooter = React.forwardRef<
+  HTMLDivElement,
+  TransactionFooterProps
+>(({ variant = 'default', className, children, ...rest }, ref) => (
+  <div
+    ref={ref}
+    className={classNames(
+      'ods-transaction-footer',
+      `ods-transaction-footer--${variant}`,
+      className
+    )}
+    {...rest}
+  >
+    {children}
+  </div>
+));
+
+TransactionFooter.displayName = 'TransactionFooter';
+
+export default TransactionFooter;

--- a/packages/ocean-react/src/TransactionFooter/__tests__/TransactionFooter.test.tsx
+++ b/packages/ocean-react/src/TransactionFooter/__tests__/TransactionFooter.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import TransactionFooter from '../TransactionFooter';
+
+test('renders the default variant when no variant is provided', () => {
+  render(
+    <TransactionFooter data-testid="footer-test" className="custom-class">
+      <span>content</span>
+    </TransactionFooter>
+  );
+
+  const element = screen.getByTestId('footer-test');
+
+  expect(element).toHaveClass(
+    'ods-transaction-footer',
+    'ods-transaction-footer--default',
+    'custom-class'
+  );
+});
+
+test('renders the highlight variant', () => {
+  render(
+    <TransactionFooter variant="highlight" data-testid="footer-test">
+      <span>content</span>
+    </TransactionFooter>
+  );
+
+  expect(screen.getByTestId('footer-test')).toHaveClass(
+    'ods-transaction-footer',
+    'ods-transaction-footer--highlight'
+  );
+});
+
+test('forwards the ref and spreads additional props', () => {
+  const ref = React.createRef<HTMLDivElement>();
+
+  render(
+    <TransactionFooter ref={ref} data-testid="footer-test" aria-label="resumo">
+      <span>content</span>
+    </TransactionFooter>
+  );
+
+  const element = screen.getByTestId('footer-test');
+
+  expect(ref.current).toBe(element);
+  expect(element).toHaveAttribute('aria-label', 'resumo');
+});
+
+test('renders the composed children', () => {
+  render(
+    <TransactionFooter>
+      <button type="button">Continuar</button>
+    </TransactionFooter>
+  );
+
+  expect(screen.getByRole('button', { name: 'Continuar' })).toBeInTheDocument();
+});

--- a/packages/ocean-react/src/TransactionFooter/index.ts
+++ b/packages/ocean-react/src/TransactionFooter/index.ts
@@ -1,0 +1,5 @@
+export { default } from './TransactionFooter';
+export type {
+  TransactionFooterProps,
+  TransactionFooterVariant,
+} from './TransactionFooter';

--- a/packages/ocean-react/src/TransactionFooter/stories/TransactionFooter.stories.tsx
+++ b/packages/ocean-react/src/TransactionFooter/stories/TransactionFooter.stories.tsx
@@ -1,5 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
+import {
+  colorInterfaceDarkDown,
+  colorInterfaceDarkUp,
+  spacingInlineXs,
+  spacingStackXxs,
+  spacingStackXxxs,
+  spacingStackXxsExtra,
+} from '@useblu/ocean-tokens/web/tokens';
 import TransactionFooter from '../TransactionFooter';
 import Typography from '../../Typography';
 import Divider from '../../Divider';
@@ -17,7 +25,7 @@ const meta: Meta<typeof TransactionFooter> = {
     },
     children: {
       description:
-        'O conteúdo do rodapé (linhas de resumo, divisor e botões), composto pelo consumidor.',
+        'O conteúdo do rodapé (Section Header, linhas de resumo, Divider e Button Bar), composto pelo consumidor.',
       control: false,
     },
   },
@@ -27,42 +35,84 @@ export default meta;
 
 type Story = StoryObj<typeof TransactionFooter>;
 
-const rowStyle: React.CSSProperties = {
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'baseline',
-  marginBottom: 8,
-};
+/* Blocos de composição espelhando a estrutura do Figma (node 25851-3910):
+ * Section Header, Inline Text List Item (label + value), Divider e Button Bar.
+ * Espaçamentos e cores vêm dos tokens Ocean. */
+
+const SectionHeader = ({ title }: { title: string }): JSX.Element => (
+  <div
+    style={{
+      padding: `${spacingStackXxs} ${spacingInlineXs} ${spacingStackXxxs}`,
+    }}
+  >
+    <Typography variant="heading5">
+      <span style={{ color: colorInterfaceDarkUp }}>{title}</span>
+    </Typography>
+  </div>
+);
 
 const Row = ({
   label,
   value,
-  bold,
 }: {
   label: string;
   value: React.ReactNode;
-  bold?: boolean;
 }): JSX.Element => (
-  <div style={rowStyle}>
-    <Typography variant="paragraph">{label}</Typography>
-    <Typography variant="paragraph">
-      {bold ? <strong>{value}</strong> : value}
-    </Typography>
+  <div
+    style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: spacingStackXxs,
+      padding: `${spacingStackXxs} ${spacingInlineXs}`,
+    }}
+  >
+    <div style={{ flex: '1 0 0' }}>
+      <Typography variant="paragraph">
+        <span style={{ color: colorInterfaceDarkDown }}>{label}</span>
+      </Typography>
+    </div>
+    <div style={{ flex: '1 0 0', textAlign: 'right' }}>
+      <Typography variant="paragraph">{value}</Typography>
+    </div>
+  </div>
+);
+
+const InternalDivider = (): JSX.Element => (
+  <div style={{ padding: `${spacingStackXxsExtra} ${spacingInlineXs}` }}>
+    <Divider />
+  </div>
+);
+
+const ButtonBar = ({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element => (
+  <div
+    style={{
+      display: 'flex',
+      flexDirection: 'column',
+      gap: spacingStackXxs,
+      padding: spacingInlineXs,
+    }}
+  >
+    {children}
   </div>
 );
 
 const Summary = (): JSX.Element => (
   <>
+    <SectionHeader title="Resumo" />
     <Row label="Você vai economizar" value="R$ 3.574,28" />
     <Row label="Custo de antecipação" value="Grátis" />
-    <Divider style={{ marginTop: 8, marginBottom: 8 }} />
-    <Row label="Total" value="R$ 42.314,10" bold />
+    <InternalDivider />
+    <Row label="Total" value="R$ 42.314,10" />
   </>
 );
 
 const decorators = [
   (StoryComponent: React.ComponentType): JSX.Element => (
-    <div style={{ maxWidth: 420 }}>
+    <div style={{ width: 393 }}>
       <StoryComponent />
     </div>
   ),
@@ -76,9 +126,28 @@ export const Usage: Story = {
   render: (args) => (
     <TransactionFooter {...args}>
       <Summary />
-      <Button variant="primary" blocked>
-        Continuar
-      </Button>
+      <ButtonBar>
+        <Button variant="primary" blocked>
+          Continuar
+        </Button>
+      </ButtonBar>
+    </TransactionFooter>
+  ),
+};
+
+export const Default: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  decorators,
+  render: () => (
+    <TransactionFooter variant="default">
+      <Summary />
+      <ButtonBar>
+        <Button variant="primary" blocked>
+          Continuar
+        </Button>
+      </ButtonBar>
     </TransactionFooter>
   ),
 };
@@ -91,9 +160,29 @@ export const Highlight: Story = {
   render: () => (
     <TransactionFooter variant="highlight">
       <Summary />
-      <Button variant="primary" blocked>
-        Continuar
-      </Button>
+      <ButtonBar>
+        <Button variant="primary" blocked>
+          Continuar
+        </Button>
+      </ButtonBar>
+    </TransactionFooter>
+  ),
+};
+
+export const WithoutHeader: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  decorators,
+  render: () => (
+    <TransactionFooter variant="highlight">
+      <Row label="Desconto" value="-R$ 1.057,85" />
+      <Row label="Pagando" value="R$ 41.256,25" />
+      <ButtonBar>
+        <Button variant="primary" blocked>
+          Confirmar pagamento
+        </Button>
+      </ButtonBar>
     </TransactionFooter>
   ),
 };
@@ -104,35 +193,16 @@ export const WithTwoButtons: Story = {
   },
   decorators,
   render: () => (
-    <TransactionFooter variant="highlight">
-      <Row label="Desconto" value="-R$ 1.057,85" />
-      <Row label="Pagando" value="R$ 41.256,25" bold />
-      <div style={{ display: 'flex', gap: 16, marginTop: 16 }}>
-        <Button variant="secondary" blocked>
-          Voltar
-        </Button>
+    <TransactionFooter variant="default">
+      <Summary />
+      <ButtonBar>
         <Button variant="primary" blocked>
           Confirmar
         </Button>
-      </div>
-    </TransactionFooter>
-  ),
-};
-
-export const WithCaption: Story = {
-  parameters: {
-    controls: { disable: true },
-  },
-  decorators,
-  render: () => (
-    <TransactionFooter variant="default">
-      <Row label="Pagando" value="R$ 41.256,25" bold />
-      <Typography variant="caption">
-        O valor pode variar conforme a data de compensação.
-      </Typography>
-      <Button variant="primary" blocked style={{ marginTop: 16 }}>
-        Confirmar pagamento
-      </Button>
+        <Button variant="secondary" blocked>
+          Voltar
+        </Button>
+      </ButtonBar>
     </TransactionFooter>
   ),
 };

--- a/packages/ocean-react/src/TransactionFooter/stories/TransactionFooter.stories.tsx
+++ b/packages/ocean-react/src/TransactionFooter/stories/TransactionFooter.stories.tsx
@@ -1,0 +1,138 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import TransactionFooter from '../TransactionFooter';
+import Typography from '../../Typography';
+import Divider from '../../Divider';
+import Button from '../../Button';
+
+const meta: Meta<typeof TransactionFooter> = {
+  title: 'Components/TransactionFooter',
+  component: TransactionFooter,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      description: 'A variante visual do rodapé.',
+      control: 'select',
+      options: ['default', 'highlight'],
+    },
+    children: {
+      description:
+        'O conteúdo do rodapé (linhas de resumo, divisor e botões), composto pelo consumidor.',
+      control: false,
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TransactionFooter>;
+
+const rowStyle: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'baseline',
+  marginBottom: 8,
+};
+
+const Row = ({
+  label,
+  value,
+  bold,
+}: {
+  label: string;
+  value: React.ReactNode;
+  bold?: boolean;
+}): JSX.Element => (
+  <div style={rowStyle}>
+    <Typography variant="paragraph">{label}</Typography>
+    <Typography variant="paragraph">
+      {bold ? <strong>{value}</strong> : value}
+    </Typography>
+  </div>
+);
+
+const Summary = (): JSX.Element => (
+  <>
+    <Row label="Você vai economizar" value="R$ 3.574,28" />
+    <Row label="Custo de antecipação" value="Grátis" />
+    <Divider style={{ marginTop: 8, marginBottom: 8 }} />
+    <Row label="Total" value="R$ 42.314,10" bold />
+  </>
+);
+
+const decorators = [
+  (StoryComponent: React.ComponentType): JSX.Element => (
+    <div style={{ maxWidth: 420 }}>
+      <StoryComponent />
+    </div>
+  ),
+];
+
+export const Usage: Story = {
+  args: {
+    variant: 'default',
+  },
+  decorators,
+  render: (args) => (
+    <TransactionFooter {...args}>
+      <Summary />
+      <Button variant="primary" blocked>
+        Continuar
+      </Button>
+    </TransactionFooter>
+  ),
+};
+
+export const Highlight: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  decorators,
+  render: () => (
+    <TransactionFooter variant="highlight">
+      <Summary />
+      <Button variant="primary" blocked>
+        Continuar
+      </Button>
+    </TransactionFooter>
+  ),
+};
+
+export const WithTwoButtons: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  decorators,
+  render: () => (
+    <TransactionFooter variant="highlight">
+      <Row label="Desconto" value="-R$ 1.057,85" />
+      <Row label="Pagando" value="R$ 41.256,25" bold />
+      <div style={{ display: 'flex', gap: 16, marginTop: 16 }}>
+        <Button variant="secondary" blocked>
+          Voltar
+        </Button>
+        <Button variant="primary" blocked>
+          Confirmar
+        </Button>
+      </div>
+    </TransactionFooter>
+  ),
+};
+
+export const WithCaption: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  decorators,
+  render: () => (
+    <TransactionFooter variant="default">
+      <Row label="Pagando" value="R$ 41.256,25" bold />
+      <Typography variant="caption">
+        O valor pode variar conforme a data de compensação.
+      </Typography>
+      <Button variant="primary" blocked style={{ marginTop: 16 }}>
+        Confirmar pagamento
+      </Button>
+    </TransactionFooter>
+  ),
+};

--- a/packages/ocean-react/src/TransactionFooter/stories/TransactionFooter.stories.tsx
+++ b/packages/ocean-react/src/TransactionFooter/stories/TransactionFooter.stories.tsx
@@ -102,11 +102,11 @@ const ButtonBar = ({
 
 const Summary = (): JSX.Element => (
   <>
-    <SectionHeader title="Resumo" />
-    <Row label="Você vai economizar" value="R$ 3.574,28" />
-    <Row label="Custo de antecipação" value="Grátis" />
+    <SectionHeader title="Title" />
+    <Row label="Title" value="Description" />
+    <Row label="Title" value="Description" />
     <InternalDivider />
-    <Row label="Total" value="R$ 42.314,10" />
+    <Row label="Title" value="Description" />
   </>
 );
 
@@ -128,7 +128,7 @@ export const Usage: Story = {
       <Summary />
       <ButtonBar>
         <Button variant="primary" blocked>
-          Continuar
+          Label
         </Button>
       </ButtonBar>
     </TransactionFooter>
@@ -145,7 +145,7 @@ export const Default: Story = {
       <Summary />
       <ButtonBar>
         <Button variant="primary" blocked>
-          Continuar
+          Label
         </Button>
       </ButtonBar>
     </TransactionFooter>
@@ -162,7 +162,7 @@ export const Highlight: Story = {
       <Summary />
       <ButtonBar>
         <Button variant="primary" blocked>
-          Continuar
+          Label
         </Button>
       </ButtonBar>
     </TransactionFooter>
@@ -176,11 +176,11 @@ export const WithoutHeader: Story = {
   decorators,
   render: () => (
     <TransactionFooter variant="highlight">
-      <Row label="Desconto" value="-R$ 1.057,85" />
-      <Row label="Pagando" value="R$ 41.256,25" />
+      <Row label="Title" value="Description" />
+      <Row label="Title" value="Description" />
       <ButtonBar>
         <Button variant="primary" blocked>
-          Confirmar pagamento
+          Label
         </Button>
       </ButtonBar>
     </TransactionFooter>
@@ -197,10 +197,10 @@ export const WithTwoButtons: Story = {
       <Summary />
       <ButtonBar>
         <Button variant="primary" blocked>
-          Confirmar
+          Primary
         </Button>
         <Button variant="secondary" blocked>
-          Voltar
+          Secondary
         </Button>
       </ButtonBar>
     </TransactionFooter>

--- a/packages/ocean-react/src/index.ts
+++ b/packages/ocean-react/src/index.ts
@@ -149,3 +149,6 @@ export * from './InternalContextualHero';
 
 export { default as ListSettings } from './ListSettings';
 export * from './ListSettings';
+
+export { default as TransactionFooter } from './TransactionFooter';
+export * from './TransactionFooter';


### PR DESCRIPTION
## Descrição

Publica o **Transaction Footer** como componente de primeira classe no `@useblu/ocean-react`. Hoje a Web não tem esse componente — os consumidores recriam a composição localmente. Este PR leva a capacidade ao Design System com a variante visual `highlight`, **fiel ao Figma do Ocean DS Core** (node `25851-3910`). Mudança **100% aditiva e retrocompatível**: componente novo + prop `variant` com default `default`.

## Tipo de mudança

`feature`

## O que está sendo resolvido

- Componente `TransactionFooter` no `@useblu/ocean-react` com prop `variant`, export no barrel, stories, docs `.mdx` e testes.
- `default` é o valor inicial (retrocompatibilidade total).
- `highlight` fiel ao Figma (fundo `colorInterfaceLightUp` + cantos superiores 16px).

## Como foi resolvido

- `packages/ocean-react/src/TransactionFooter/TransactionFooter.tsx` — `forwardRef`, `children` livre (menor superfície pública, espelha a composição usada hoje), prop `variant?: 'default' | 'highlight'` (default `'default'`).
- `packages/ocean-core/src/components/_transaction-footer.scss` — BEM `.ods-transaction-footer`. Espaçador de topo de 8px em ambas as variantes; `--default` desenha o **divisor de topo** (`$color-interface-light-down`) via `::before` **dentro** desses 8px (não adiciona altura → sem "pulo" ao alternar); `--highlight` = `$color-interface-light-up` + `border-top-left/right-radius: $border-radius-lg` (16px). O padding é por seção (linhas/button bar), como no Figma. Registrado em `_all.scss`.
- Export em `packages/ocean-react/src/index.ts` (+ `index.ts` do componente com `TransactionFooterProps`/`TransactionFooterVariant`).
- Stories reproduzindo **fielmente a estrutura do Figma** com tokens Ocean: Section Header (`heading5` / `colorInterfaceDarkUp` `#AAADC0`), linhas de resumo (label `colorInterfaceDarkDown` `#67697A` / valor `colorInterfaceDarkDeep` `#393B47`, `paragraph` 16px, `px 16 / py 8`, `gap 8`), Divider interno (`px 16 / py 12`) e Button Bar (`p 16`) com o Primary pill de 48px.
- Docs `packages/ocean-docs/docs/components/transactionfooter.mdx` (exemplos live fiéis + tabela "tokens usados" + "quando NÃO usar") + registro em `sidebars.ts`.
- Testes (`__tests__/TransactionFooter.test.tsx`) — **100% de cobertura**.

### Fidelidade ao Figma (tokens revisados)

| Elemento | Token | Valor |
|---|---|---|
| Fundo `default` / `highlight` | `colorInterfaceLightPure` / `colorInterfaceLightUp` | `#FFFFFF` / `#F3F5FE` |
| Divisores | `colorInterfaceLightDown` | `#E0E2EE` |
| Cantos `highlight` | `borderRadiusLg` | `16px` |
| Section Header | `heading5` / `colorInterfaceDarkUp` | Nunito Sans Bold 14 / `#AAADC0` |
| Label / Valor | `paragraph` / `colorInterfaceDarkDown` · `colorInterfaceDarkDeep` | 16px / `#67697A` · `#393B47` |
| Botão primário | `colorBrandPrimaryPure` / `borderRadiusCircular` | `#0025E0` / pill 48px |

> Nota cross-plataforma: as 3 plataformas (Web, Android e iOS) foram alinhadas ao Figma — a `default` exibe o divisor de topo e a `highlight` os cantos superiores de 16px em todas. No mobile o ajuste é **somente de layout** (sem alterar props existentes), então as integrações atuais não quebram. PRs irmãs: Android e iOS.

## Cenários de teste

Rodados localmente:

- ✅ `eslint` + `prettier --check` — sem ofensas.
- ✅ `stylelint _transaction-footer.scss` — ok; SCSS compila (dart-sass).
- ✅ `jest TransactionFooter --coverage` — 4 testes, **100%** (stmts/branch/funcs/lines).

O reviewer deve validar via **Chromatic** (Storybook) as stories `Default`/`Highlight` contra o Figma (node `25851-3910`): contraste AA, cantos 16px, divisor de topo da `default`, ausência de "pulo" ao alternar. Build completo do monorepo e Chromatic rodam no CI.

## Links

- **Jira:** [MR-513](https://useblu.atlassian.net/browse/MR-513)
- **Figma:** Ocean DS Core — node `25851-3910`

## Breaking changes

Nenhum — mudança aditiva (novo componente + prop opcional com default).
