### PR TITLE
feat(list): adiciona indicatorPosition nos componentes de lista

### DIFF
--- a/packages/ocean-core/src/components/_content-list.scss
+++ b/packages/ocean-core/src/components/_content-list.scss
@@ -4,9 +4,9 @@
   flex-direction: column;
   min-width: 0;
 
-  // NÃO adicionar `gap` aqui: o espaçamento entre título, descrição e caption vem do
-  // `margin-top` do caption, e um `gap` no container regrediria todos os componentes
-  // que usam o ContentList. O respiro do indicator empilhado vai no `margin` dele.
+  // Do NOT add `gap` here: the spacing between title, description and caption comes from
+  // the caption's `margin-top`, and a `gap` on the container would regress every component
+  // that uses ContentList. The stacked indicator's breathing room goes in its own `margin`.
   &__indicator {
     align-self: flex-start;
     display: flex;

--- a/packages/ocean-core/src/components/_content-list.scss
+++ b/packages/ocean-core/src/components/_content-list.scss
@@ -4,6 +4,22 @@
   flex-direction: column;
   min-width: 0;
 
+  // NÃO adicionar `gap` aqui: o espaçamento entre título, descrição e caption vem do
+  // `margin-top` do caption, e um `gap` no container regrediria todos os componentes
+  // que usam o ContentList. O respiro do indicator empilhado vai no `margin` dele.
+  &__indicator {
+    align-self: flex-start;
+    display: flex;
+
+    &--above {
+      margin-bottom: $spacing-stack-xxs;
+    }
+
+    &--below {
+      margin-top: $spacing-stack-xxs;
+    }
+  }
+
   .ods-typography__paragraph {
     color: $color-interface-dark-deep;
   }

--- a/packages/ocean-core/src/components/_list-expandable.scss
+++ b/packages/ocean-core/src/components/_list-expandable.scss
@@ -104,8 +104,8 @@
     border: 0;
     cursor: pointer;
     display: flex;
-    // Alinhado ao Figma (Card List Expandable, itemSpacing 12 -> 8 nas 18 variantes):
-    // o mesmo token do respiro do indicator empilhado.
+    // Aligned with Figma (Card List Expandable, itemSpacing 12 -> 8 across the 18 variants):
+    // the same token as the stacked indicator's breathing room.
     gap: $spacing-stack-xxs;
     min-width: 0; // Prevent button from overflowing
     padding: $spacing-inline-xs $spacing-inline-xxs $spacing-inline-xs

--- a/packages/ocean-core/src/components/_list-expandable.scss
+++ b/packages/ocean-core/src/components/_list-expandable.scss
@@ -104,7 +104,9 @@
     border: 0;
     cursor: pointer;
     display: flex;
-    gap: $spacing-inline-xxs-extra;
+    // Alinhado ao Figma (Card List Expandable, itemSpacing 12 -> 8 nas 18 variantes):
+    // o mesmo token do respiro do indicator empilhado.
+    gap: $spacing-stack-xxs;
     min-width: 0; // Prevent button from overflowing
     padding: $spacing-inline-xs $spacing-inline-xxs $spacing-inline-xs
       $spacing-inline-xs;

--- a/packages/ocean-docs/docs/components/listaction.mdx
+++ b/packages/ocean-docs/docs/components/listaction.mdx
@@ -505,26 +505,27 @@ Mostra um skeleton placeholder durante carregamento:
 
 ### Props
 
-| Prop                       | Tipo                                                                                                       | Padrão           | Descrição                                                    |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------- | ---------------- | ------------------------------------------------------------ |
-| `title`                    | `string`                                                                                                   | -                | Título principal do item (obrigatório)                       |
-| `description`              | `string`                                                                                                   | -                | Descrição ou texto secundário                                |
-| `strikethroughDescription` | `string`                                                                                                   | -                | Descrição com texto riscado (valor antigo)                   |
-| `caption`                  | `string`                                                                                                   | -                | Legenda ou texto terciário                                   |
-| `inverted`                 | `boolean`                                                                                                  | `false`          | Inverte posição do título com descrição                      |
-| `type`                     | `'card' \| 'text'`                                                                                         | `'card'`         | Tipo de borda do item                                        |
-| `status`                   | `'default' \| 'inactive' \| 'positive' \| 'warning' \| 'highlight' \| 'highlight-lead' \| 'strikethrough'` | `'default'`      | Status visual do conteúdo                                    |
-| `showDivider`              | `boolean`                                                                                                  | `false`          | Mostra divisor entre itens (apenas para `type="text"`)       |
-| `highlight`                | `{ caption: string \| ReactNode; backgroundColor?: string; captionColor?: string }`                        | -                | Exibe área de destaque com texto ou conteúdo na base do card |
-| `disabled`                 | `boolean`                                                                                                  | `false`          | Desabilita o item                                            |
-| `loading`                  | `boolean`                                                                                                  | `false`          | Exibe skeleton de carregamento                               |
-| `icon`                     | `ReactNode`                                                                                                | -                | Ícone exibido no início do item                              |
-| `indicator`                | `ReactNode`                                                                                                | -                | Indicador (badge/tag) antes da ação                          |
-| `actionType`               | `'chevron' \| 'menu' \| 'swipe'`                                                                           | `'chevron'`      | Tipo de ação do item                                         |
-| `menuActions`              | `ActionItem[]`                                                                                             | -                | Lista de ações para tipos menu/swipe                         |
-| `menuPosition`             | `'bottom-left' \| 'bottom-right' \| 'top-left' \| 'top-right'`                                             | `'bottom-right'` | Posição do menu dropdown                                     |
-| `onClick`                  | `(event: React.MouseEvent<HTMLButtonElement>) => void`                                                     | -                | Função chamada ao clicar no item                             |
-| `className`                | `string`                                                                                                   | -                | Classes CSS adicionais                                       |
+| Prop                       | Tipo                                                                                                       | Padrão           | Descrição                                                                                                         |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `title`                    | `string`                                                                                                   | -                | Título principal do item (obrigatório)                                                                            |
+| `description`              | `string`                                                                                                   | -                | Descrição ou texto secundário                                                                                     |
+| `strikethroughDescription` | `string`                                                                                                   | -                | Descrição com texto riscado (valor antigo)                                                                        |
+| `caption`                  | `string`                                                                                                   | -                | Legenda ou texto terciário                                                                                        |
+| `inverted`                 | `boolean`                                                                                                  | `false`          | Inverte posição do título com descrição                                                                           |
+| `type`                     | `'card' \| 'text'`                                                                                         | `'card'`         | Tipo de borda do item                                                                                             |
+| `status`                   | `'default' \| 'inactive' \| 'positive' \| 'warning' \| 'highlight' \| 'highlight-lead' \| 'strikethrough'` | `'default'`      | Status visual do conteúdo                                                                                         |
+| `showDivider`              | `boolean`                                                                                                  | `false`          | Mostra divisor entre itens (apenas para `type="text"`)                                                            |
+| `highlight`                | `{ caption: string \| ReactNode; backgroundColor?: string; captionColor?: string }`                        | -                | Exibe área de destaque com texto ou conteúdo na base do card                                                      |
+| `disabled`                 | `boolean`                                                                                                  | `false`          | Desabilita o item                                                                                                 |
+| `loading`                  | `boolean`                                                                                                  | `false`          | Exibe skeleton de carregamento                                                                                    |
+| `icon`                     | `ReactNode`                                                                                                | -                | Ícone exibido no início do item                                                                                   |
+| `indicator`                | `ReactNode`                                                                                                | -                | Indicador (badge/tag) antes da ação                                                                               |
+| `indicatorPosition`        | `'inline' \| 'above' \| 'below'`                                                                           | `'inline'`       | Posição do `indicator` em relação ao texto. Não confundir com `position` (timeline) nem `menuPosition` (dropdown) |
+| `actionType`               | `'chevron' \| 'menu' \| 'swipe'`                                                                           | `'chevron'`      | Tipo de ação do item                                                                                              |
+| `menuActions`              | `ActionItem[]`                                                                                             | -                | Lista de ações para tipos menu/swipe                                                                              |
+| `menuPosition`             | `'bottom-left' \| 'bottom-right' \| 'top-left' \| 'top-right'`                                             | `'bottom-right'` | Posição do menu dropdown                                                                                          |
+| `onClick`                  | `(event: React.MouseEvent<HTMLButtonElement>) => void`                                                     | -                | Função chamada ao clicar no item                                                                                  |
+| `className`                | `string`                                                                                                   | -                | Classes CSS adicionais                                                                                            |
 
 ### ActionItem (menuActions)
 
@@ -639,3 +640,31 @@ No Storybook você encontrará:
 - [TransactionListItem](/components/transactionlistitem) - Para transações financeiras
 - [SettingsListItem](/components/settingslistitem) - Para itens de configuração
 - [Storybook - ListAction](https://ocean-ds.github.io/ocean-web/?path=/docs/components-list-listaction--docs)
+
+## Posição do indicator
+
+A prop `indicatorPosition` define onde o `indicator` é renderizado em relação ao texto:
+
+| Valor              | Comportamento                                                                                                            |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| `inline` (default) | Mantém a posição atual do componente — mesma linha do texto, no fim do bloco de conteúdo. Nenhuma tela em produção muda. |
+| `above`            | Empilha o indicator **acima do título**, dentro do bloco de conteúdo.                                                    |
+| `below`            | Empilha o indicator **abaixo do texto**, dentro do bloco de conteúdo.                                                    |
+
+O indicator pertence ao bloco de conteúdo, nunca ao slot do controle: em qualquer posição o
+chevron, o menu, o radio/checkbox e o `amountDetails` permanecem onde estão. Nas posições
+empilhadas o respiro é de 8px (`spacingStackXxs`) e o indicator fica alinhado à esquerda.
+
+A prop não tem efeito quando `indicator` não é informado.
+
+```jsx
+<Component
+  title="Limite de compra adicional"
+  description="Pague em até 3x"
+  indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+  indicatorPosition="above"
+/>
+```
+
+> **Não confundir:** `indicatorPosition` posiciona o _indicator_; `position` desenha a
+> _timeline_ (`first`/`middle`/`last`) e `menuPosition` posiciona o _dropdown_ do menu.

--- a/packages/ocean-docs/docs/components/listexpandable.mdx
+++ b/packages/ocean-docs/docs/components/listexpandable.mdx
@@ -353,6 +353,7 @@ Veja como controlar o estado de expansão externamente:
 | `highlight`                | `{ caption: string \| ReactNode; backgroundColor?: string; captionColor?: string }`                        | -           | Exibe área de destaque com texto ou conteúdo na base do card |
 | `icon`                     | `ReactNode`                                                                                                | -           | Ícone à esquerda do conteúdo                                 |
 | `indicator`                | `ReactNode`                                                                                                | -           | Badge/Tag antes da ação de expansão                          |
+| `indicatorPosition`        | `'inline' \| 'above' \| 'below'`                                                                           | `'inline'`  | Posição do `indicator` em relação ao texto                   |
 | `expanded`                 | `boolean`                                                                                                  | -           | Controla estado expandido (controlled)                       |
 | `defaultExpanded`          | `boolean`                                                                                                  | `false`     | Estado inicial (uncontrolled)                                |
 | `onToggle`                 | `(expanded: boolean) => void`                                                                              | -           | Callback ao expandir/colapsar                                |
@@ -512,3 +513,28 @@ Veja como controlar o estado de expansão externamente:
 - [Tag](/components/tag) - Para indicadores de status
 - [Accordion](/components/accordion) - Para seções expansíveis de página
 - [Storybook - ListExpandable](https://ocean-ds.github.io/ocean-web/?path=/docs/components-list-listexpandable--docs) - Documentação técnica completa
+
+## Posição do indicator
+
+A prop `indicatorPosition` define onde o `indicator` é renderizado em relação ao texto:
+
+| Valor              | Comportamento                                                                                                            |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| `inline` (default) | Mantém a posição atual do componente — mesma linha do texto, no fim do bloco de conteúdo. Nenhuma tela em produção muda. |
+| `above`            | Empilha o indicator **acima do título**, dentro do bloco de conteúdo.                                                    |
+| `below`            | Empilha o indicator **abaixo do texto**, dentro do bloco de conteúdo.                                                    |
+
+O indicator pertence ao bloco de conteúdo, nunca ao slot do controle: em qualquer posição o
+chevron, o menu, o radio/checkbox e o `amountDetails` permanecem onde estão. Nas posições
+empilhadas o respiro é de 8px (`spacingStackXxs`) e o indicator fica alinhado à esquerda.
+
+A prop não tem efeito quando `indicator` não é informado.
+
+```jsx
+<Component
+  title="Limite de compra adicional"
+  description="Pague em até 3x"
+  indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+  indicatorPosition="above"
+/>
+```

--- a/packages/ocean-docs/docs/components/listreadonly.mdx
+++ b/packages/ocean-docs/docs/components/listreadonly.mdx
@@ -472,22 +472,23 @@ Mostra um skeleton placeholder durante carregamento:
 
 ### Props
 
-| Prop                       | Tipo                                                                                                       | Padrão      | Descrição                                                    |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------- | ----------- | ------------------------------------------------------------ |
-| `title`                    | `string`                                                                                                   | -           | Título principal do card (obrigatório)                       |
-| `description`              | `string`                                                                                                   | -           | Descrição ou texto secundário                                |
-| `strikethroughDescription` | `string`                                                                                                   | -           | Descrição com texto riscado (valor antigo)                   |
-| `caption`                  | `string`                                                                                                   | -           | Legenda ou texto terciário                                   |
-| `inverted`                 | `boolean`                                                                                                  | `false`     | Inverte posição do título com descrição                      |
-| `type`                     | `'card' \| 'text'`                                                                                         | `'card'`    | Tipo de exibição visual do item                              |
-| `status`                   | `'default' \| 'inactive' \| 'positive' \| 'warning' \| 'highlight' \| 'highlight-lead' \| 'strikethrough'` | `'default'` | Status visual do conteúdo                                    |
-| `disabled`                 | `boolean`                                                                                                  | `false`     | Desabilita o card (visual apenas)                            |
-| `loading`                  | `boolean`                                                                                                  | `false`     | Exibe skeleton de carregamento                               |
-| `icon`                     | `ReactNode`                                                                                                | -           | Ícone exibido no início do card                              |
-| `indicator`                | `ReactNode`                                                                                                | -           | Indicador (badge/tag) à direita                              |
-| `showDivider`              | `boolean`                                                                                                  | `false`     | Mostra divisor entre itens (apenas para type=text)           |
-| `highlight`                | `{ caption: string \| ReactNode; backgroundColor?: string; captionColor?: string }`                        | -           | Exibe área de destaque com texto ou conteúdo na base do card |
-| `className`                | `string`                                                                                                   | -           | Classes CSS adicionais                                       |
+| Prop                       | Tipo                                                                                                       | Padrão      | Descrição                                                          |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------ |
+| `title`                    | `string`                                                                                                   | -           | Título principal do card (obrigatório)                             |
+| `description`              | `string`                                                                                                   | -           | Descrição ou texto secundário                                      |
+| `strikethroughDescription` | `string`                                                                                                   | -           | Descrição com texto riscado (valor antigo)                         |
+| `caption`                  | `string`                                                                                                   | -           | Legenda ou texto terciário                                         |
+| `inverted`                 | `boolean`                                                                                                  | `false`     | Inverte posição do título com descrição                            |
+| `type`                     | `'card' \| 'text'`                                                                                         | `'card'`    | Tipo de exibição visual do item                                    |
+| `status`                   | `'default' \| 'inactive' \| 'positive' \| 'warning' \| 'highlight' \| 'highlight-lead' \| 'strikethrough'` | `'default'` | Status visual do conteúdo                                          |
+| `disabled`                 | `boolean`                                                                                                  | `false`     | Desabilita o card (visual apenas)                                  |
+| `loading`                  | `boolean`                                                                                                  | `false`     | Exibe skeleton de carregamento                                     |
+| `icon`                     | `ReactNode`                                                                                                | -           | Ícone exibido no início do card                                    |
+| `indicator`                | `ReactNode`                                                                                                | -           | Indicador (badge/tag) — posição controlada por `indicatorPosition` |
+| `indicatorPosition`        | `'inline' \| 'above' \| 'below'`                                                                           | `'inline'`  | Posição do `indicator` em relação ao texto                         |
+| `showDivider`              | `boolean`                                                                                                  | `false`     | Mostra divisor entre itens (apenas para type=text)                 |
+| `highlight`                | `{ caption: string \| ReactNode; backgroundColor?: string; captionColor?: string }`                        | -           | Exibe área de destaque com texto ou conteúdo na base do card       |
+| `className`                | `string`                                                                                                   | -           | Classes CSS adicionais                                             |
 
 ## Acessibilidade
 
@@ -584,3 +585,28 @@ No Storybook você encontrará:
 - [Tag](/components/tag) - Para indicadores de categoria/status
 - [Typography](/components/typography) - Para formatação de texto
 - [Storybook - ListReadOnly](https://ocean-ds.github.io/ocean-web/?path=/docs/components-list-listreadonly--docs)
+
+## Posição do indicator
+
+A prop `indicatorPosition` define onde o `indicator` é renderizado em relação ao texto:
+
+| Valor              | Comportamento                                                                                                            |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| `inline` (default) | Mantém a posição atual do componente — mesma linha do texto, no fim do bloco de conteúdo. Nenhuma tela em produção muda. |
+| `above`            | Empilha o indicator **acima do título**, dentro do bloco de conteúdo.                                                    |
+| `below`            | Empilha o indicator **abaixo do texto**, dentro do bloco de conteúdo.                                                    |
+
+O indicator pertence ao bloco de conteúdo, nunca ao slot do controle: em qualquer posição o
+chevron, o menu, o radio/checkbox e o `amountDetails` permanecem onde estão. Nas posições
+empilhadas o respiro é de 8px (`spacingStackXxs`) e o indicator fica alinhado à esquerda.
+
+A prop não tem efeito quando `indicator` não é informado.
+
+```jsx
+<Component
+  title="Limite de compra adicional"
+  description="Pague em até 3x"
+  indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+  indicatorPosition="above"
+/>
+```

--- a/packages/ocean-docs/docs/components/listselectable.mdx
+++ b/packages/ocean-docs/docs/components/listselectable.mdx
@@ -162,6 +162,7 @@ Quando `isSelectableDisabled` é fornecida, o componente oculta os controles de 
 | `checkbox`                 | `CheckboxProps`                                                                                            | -           | Props do componente Checkbox para seleção múltipla                                       |
 | `radio`                    | `RadioProps`                                                                                               | -           | Props do componente Radio para seleção única                                             |
 | `indicator`                | `ReactNode`                                                                                                | -           | Elemento visual indicador (Badge, Tag, etc.)                                             |
+| `indicatorPosition`        | `'inline' \| 'above' \| 'below'`                                                                           | `'inline'`  | Posição do `indicator` em relação ao texto                                               |
 | `isSelectableDisabled`     | `boolean`                                                                                                  | `false`     | Quando `true`, oculta os controles de seleção e renderiza o conteúdo como `ListReadOnly` |
 | `highlight`                | `{ caption: string \| ReactNode; backgroundColor?: string; captionColor?: string }`                        | -           | Exibe área de destaque com texto ou conteúdo na base do card                             |
 | `className`                | `string`                                                                                                   | -           | Classes CSS adicionais                                                                   |
@@ -196,3 +197,28 @@ Quando `isSelectableDisabled` é fornecida, o componente oculta os controles de 
 - [Radio](/components/radio)
 - [Badge](/components/badge)
 - [Tag](/components/tag)
+
+## Posição do indicator
+
+A prop `indicatorPosition` define onde o `indicator` é renderizado em relação ao texto:
+
+| Valor              | Comportamento                                                                                                            |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| `inline` (default) | Mantém a posição atual do componente — mesma linha do texto, no fim do bloco de conteúdo. Nenhuma tela em produção muda. |
+| `above`            | Empilha o indicator **acima do título**, dentro do bloco de conteúdo.                                                    |
+| `below`            | Empilha o indicator **abaixo do texto**, dentro do bloco de conteúdo.                                                    |
+
+O indicator pertence ao bloco de conteúdo, nunca ao slot do controle: em qualquer posição o
+chevron, o menu, o radio/checkbox e o `amountDetails` permanecem onde estão. Nas posições
+empilhadas o respiro é de 8px (`spacingStackXxs`) e o indicator fica alinhado à esquerda.
+
+A prop não tem efeito quando `indicator` não é informado.
+
+```jsx
+<Component
+  title="Limite de compra adicional"
+  description="Pague em até 3x"
+  indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+  indicatorPosition="above"
+/>
+```

--- a/packages/ocean-react/src/ListAction/ListAction.tsx
+++ b/packages/ocean-react/src/ListAction/ListAction.tsx
@@ -192,8 +192,8 @@ const ListAction = React.forwardRef<HTMLButtonElement, ListActionProps>(
         ? { transform: `translateX(-${menuWidth}px)` }
         : {};
 
-    // Só `above`/`below` vão para dentro do ContentList; `inline` mantém o wrapper
-    // atual do componente, preservando o DOM em produção.
+    // Only `above`/`below` are passed into ContentList; `inline` keeps the component's
+    // current wrapper, preserving the production DOM.
     const stackedPosition =
       indicatorPosition !== 'inline' ? indicatorPosition : undefined;
 

--- a/packages/ocean-react/src/ListAction/ListAction.tsx
+++ b/packages/ocean-react/src/ListAction/ListAction.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { ChevronRight } from '@useblu/ocean-icons-react';
 import ContentList, {
   ContentListProps,
+  IndicatorPosition,
 } from '../_shared/components/ContentList';
 import SkeletonBar from '../_shared/components/SkeletonBar';
 import InternalListActions, {
@@ -66,6 +67,18 @@ export type ListActionProps = {
    */
   indicator?: ReactNode;
   /**
+   * Where the `indicator` is rendered relative to the text content.
+   *
+   * - `inline` (default): same row as the text, at the end of the content block.
+   * - `above`: stacked above the title, inside the content column.
+   * - `below`: stacked below the text, inside the content column.
+   *
+   * Has no effect when `indicator` is not provided. Not to be confused with
+   * `position` (timeline) or `menuPosition` (dropdown).
+   * @default 'inline'
+   */
+  indicatorPosition?: IndicatorPosition;
+  /**
    * The type of action displayed on the card.
    * @default 'chevron'
    */
@@ -117,6 +130,7 @@ const ListAction = React.forwardRef<HTMLButtonElement, ListActionProps>(
       loading = false,
       icon,
       indicator,
+      indicatorPosition = 'inline',
       actionType = 'chevron',
       menuActions,
       menuPosition = 'bottom-right',
@@ -178,6 +192,11 @@ const ListAction = React.forwardRef<HTMLButtonElement, ListActionProps>(
         ? { transform: `translateX(-${menuWidth}px)` }
         : {};
 
+    // Só `above`/`below` vão para dentro do ContentList; `inline` mantém o wrapper
+    // atual do componente, preservando o DOM em produção.
+    const stackedPosition =
+      indicatorPosition !== 'inline' ? indicatorPosition : undefined;
+
     const showLeading = position && icon;
     const showLineAbove = position === 'middle' || position === 'last';
     const showLineBelow = position === 'first' || position === 'middle';
@@ -223,9 +242,11 @@ const ListAction = React.forwardRef<HTMLButtonElement, ListActionProps>(
             caption={caption}
             inverted={inverted}
             type={status}
+            indicator={stackedPosition ? indicator : undefined}
+            indicatorPosition={stackedPosition}
           />
           {amountDetails && <AmountDetails type={status} {...amountDetails} />}
-          {indicator && (
+          {indicator && !stackedPosition && (
             <div className="ods-list-action__indicator">{indicator}</div>
           )}
         </div>

--- a/packages/ocean-react/src/ListAction/__tests__/ListAction.test.tsx
+++ b/packages/ocean-react/src/ListAction/__tests__/ListAction.test.tsx
@@ -425,4 +425,93 @@ describe('ListAction', () => {
       ).not.toBeInTheDocument();
     });
   });
+
+  describe('indicatorPosition', () => {
+    const indicator = <Tag type="positive">3x sem acréscimo</Tag>;
+
+    test('CT-1: keeps the current wrapper when the prop is omitted', () => {
+      render(<ListAction title="Title" indicator={indicator} />);
+
+      const tag = screen.getByText('3x sem acréscimo');
+
+      expect(tag.closest('.ods-list-action__indicator')).toBeInTheDocument();
+      expect(tag.closest('.ods-content-list__indicator')).toBeNull();
+    });
+
+    test('CT-4: explicit inline renders the same tree as the default', () => {
+      const { asFragment: defaultTree } = render(
+        <ListAction title="Title" indicator={indicator} />
+      );
+      const { asFragment: inlineTree } = render(
+        <ListAction
+          title="Title"
+          indicator={indicator}
+          indicatorPosition="inline"
+        />
+      );
+
+      expect(inlineTree()).toEqual(defaultTree());
+    });
+
+    test('CT-2: renders above as the first child of the content column', () => {
+      render(
+        <ListAction
+          title="Title"
+          description="Description"
+          indicator={indicator}
+          indicatorPosition="above"
+        />
+      );
+
+      const content = screen.getByText('Title').closest('.ods-content-list');
+
+      expect(content?.firstElementChild).toHaveClass(
+        'ods-content-list__indicator--above'
+      );
+      expect(
+        screen
+          .getByText('3x sem acréscimo')
+          .closest('.ods-list-action__indicator')
+      ).toBeNull();
+    });
+
+    test('CT-10: swipe mode still renders with the indicator stacked', () => {
+      render(
+        <ListAction
+          title="Title"
+          actionType="swipe"
+          menuActions={[{ label: 'Delete', onClick: jest.fn() }]}
+          indicator={indicator}
+          indicatorPosition="above"
+        />
+      );
+
+      const tag = screen.getByText('3x sem acréscimo');
+
+      expect(tag.closest('.ods-list-action--swipe-mode')).toBeInTheDocument();
+      expect(tag.closest('.ods-list-action__indicator')).toBeNull();
+      expect(
+        tag.closest('.ods-content-list__indicator--above')
+      ).toBeInTheDocument();
+    });
+
+    test('indicatorPosition does not interfere with position (timeline)', () => {
+      render(
+        <ListAction
+          title="Title"
+          icon={<PlaceholderOutline />}
+          position="middle"
+          indicator={indicator}
+          indicatorPosition="above"
+        />
+      );
+
+      const tag = screen.getByText('3x sem acréscimo');
+
+      expect(tag.closest('.ods-list-action')).toBeInTheDocument();
+      expect(
+        tag.closest('.ods-content-list__indicator--above')
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/ocean-react/src/ListAction/stories/ListAction.stories.tsx
+++ b/packages/ocean-react/src/ListAction/stories/ListAction.stories.tsx
@@ -814,3 +814,47 @@ export const WithHighlight: Story = {
     </div>
   ),
 };
+
+export const IndicatorPosition: Story = {
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story:
+          'A prop `indicatorPosition` define onde o `indicator` fica em relação ao texto. ' +
+          '`inline` (default) mantém o comportamento atual — mesma linha do texto, no fim do ' +
+          'bloco de conteúdo. `above` e `below` empilham dentro do bloco de conteúdo, com 8px ' +
+          'de respiro e alinhados à esquerda. O slot do controle nunca recebe o indicator.',
+      },
+    },
+  },
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 16,
+        minWidth: 320,
+      }}
+    >
+      <ListAction
+        title="inline (default)"
+        description="Comportamento atual — nenhuma tela em produção muda"
+        indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+      />
+      <ListAction
+        title="above"
+        description="Tag empilhada acima do título"
+        indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+        indicatorPosition="above"
+      />
+      <ListAction
+        title="below"
+        description="Tag empilhada abaixo do texto"
+        caption="Caption"
+        indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+        indicatorPosition="below"
+      />
+    </div>
+  ),
+};

--- a/packages/ocean-react/src/ListAction/stories/ListAction.stories.tsx
+++ b/packages/ocean-react/src/ListAction/stories/ListAction.stories.tsx
@@ -12,6 +12,11 @@ import type { ActionItem } from '../../_shared/components/InternalListActions';
 import Badge from '../../Badge';
 import Tag from '../../Tag';
 import List from '../../List';
+import {
+  indicatorPositionCases,
+  indicatorPositionStackStyle,
+  indicatorPositionStoryConfig,
+} from '../../_stories/components/indicatorPosition';
 
 const meta: Meta<typeof ListAction> = {
   title: 'Components/List/ListAction',
@@ -815,62 +820,13 @@ export const WithHighlight: Story = {
   ),
 };
 
-const positionIndicatorOptions = {
-  tag: <Tag type="positive">3x sem acréscimo</Tag>,
-  withoutIndicator: undefined,
-};
-
 export const IndicatorPosition: Story = {
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'The `indicatorPosition` prop sets where the `indicator` sits relative to the text. ' +
-          '`inline` (default) keeps the current behaviour — same row as the text, at the end ' +
-          'of the content block. `above` and `below` stack it inside the content block, with ' +
-          '8px of breathing room, left-aligned. The control slot never receives the indicator.',
-      },
-    },
-  },
-  argTypes: {
-    indicator: {
-      options: Object.keys(positionIndicatorOptions),
-      mapping: positionIndicatorOptions,
-      control: { type: 'radio' },
-      description:
-        'Toggles the indicator on and off in the three positions below.',
-    },
-  },
-  args: {
-    indicator: 'tag' as unknown as React.ReactNode,
-  },
+  ...indicatorPositionStoryConfig,
   render: ({ indicator }) => (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 16,
-        minWidth: 320,
-      }}
-    >
-      <ListAction
-        title="inline (default)"
-        description="Current behaviour — nothing changes in production"
-        indicator={indicator}
-      />
-      <ListAction
-        title="above"
-        description="Tag stacked above the title"
-        indicator={indicator}
-        indicatorPosition="above"
-      />
-      <ListAction
-        title="below"
-        description="Tag stacked below the text"
-        caption="Caption"
-        indicator={indicator}
-        indicatorPosition="below"
-      />
+    <div style={indicatorPositionStackStyle}>
+      {indicatorPositionCases.map(({ id, ...caseProps }) => (
+        <ListAction key={id} {...caseProps} indicator={indicator} />
+      ))}
     </div>
   ),
 };

--- a/packages/ocean-react/src/ListAction/stories/ListAction.stories.tsx
+++ b/packages/ocean-react/src/ListAction/stories/ListAction.stories.tsx
@@ -815,20 +815,36 @@ export const WithHighlight: Story = {
   ),
 };
 
+const positionIndicatorOptions = {
+  tag: <Tag type="positive">3x sem acréscimo</Tag>,
+  withoutIndicator: undefined,
+};
+
 export const IndicatorPosition: Story = {
   parameters: {
-    controls: { disable: true },
     docs: {
       description: {
         story:
-          'A prop `indicatorPosition` define onde o `indicator` fica em relação ao texto. ' +
-          '`inline` (default) mantém o comportamento atual — mesma linha do texto, no fim do ' +
-          'bloco de conteúdo. `above` e `below` empilham dentro do bloco de conteúdo, com 8px ' +
-          'de respiro e alinhados à esquerda. O slot do controle nunca recebe o indicator.',
+          'The `indicatorPosition` prop sets where the `indicator` sits relative to the text. ' +
+          '`inline` (default) keeps the current behaviour — same row as the text, at the end ' +
+          'of the content block. `above` and `below` stack it inside the content block, with ' +
+          '8px of breathing room, left-aligned. The control slot never receives the indicator.',
       },
     },
   },
-  render: () => (
+  argTypes: {
+    indicator: {
+      options: Object.keys(positionIndicatorOptions),
+      mapping: positionIndicatorOptions,
+      control: { type: 'radio' },
+      description:
+        'Toggles the indicator on and off in the three positions below.',
+    },
+  },
+  args: {
+    indicator: 'tag' as unknown as React.ReactNode,
+  },
+  render: ({ indicator }) => (
     <div
       style={{
         display: 'flex',
@@ -839,20 +855,20 @@ export const IndicatorPosition: Story = {
     >
       <ListAction
         title="inline (default)"
-        description="Comportamento atual — nenhuma tela em produção muda"
-        indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+        description="Current behaviour — nothing changes in production"
+        indicator={indicator}
       />
       <ListAction
         title="above"
-        description="Tag empilhada acima do título"
-        indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+        description="Tag stacked above the title"
+        indicator={indicator}
         indicatorPosition="above"
       />
       <ListAction
         title="below"
-        description="Tag empilhada abaixo do texto"
+        description="Tag stacked below the text"
         caption="Caption"
-        indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+        indicator={indicator}
         indicatorPosition="below"
       />
     </div>

--- a/packages/ocean-react/src/ListExpandable/ListExpandable.tsx
+++ b/packages/ocean-react/src/ListExpandable/ListExpandable.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { ChevronDown, ChevronUp } from '@useblu/ocean-icons-react';
 import ContentList, {
   ContentListProps,
+  IndicatorPosition,
 } from '../_shared/components/ContentList';
 import SkeletonBar from '../_shared/components/SkeletonBar';
 import ListContainer, {
@@ -55,6 +56,17 @@ export type ListExpandableProps = {
    */
   indicator?: ReactNode;
   /**
+   * Where the `indicator` is rendered relative to the text content.
+   *
+   * - `inline` (default): same row as the text, before the chevron.
+   * - `above`: stacked above the title, inside the content column.
+   * - `below`: stacked below the text, inside the content column.
+   *
+   * Has no effect when `indicator` is not provided.
+   * @default 'inline'
+   */
+  indicatorPosition?: IndicatorPosition;
+  /**
    * Controls the expanded state (controlled component).
    */
   expanded?: boolean;
@@ -100,6 +112,7 @@ const ListExpandable = React.forwardRef<HTMLDivElement, ListExpandableProps>(
       loading = false,
       icon,
       indicator,
+      indicatorPosition = 'inline',
       expanded: controlledExpanded,
       defaultExpanded = false,
       onToggle,
@@ -134,6 +147,11 @@ const ListExpandable = React.forwardRef<HTMLDivElement, ListExpandableProps>(
       </div>
     );
 
+    // Só `above`/`below` vão para dentro do ContentList; `inline` mantém o wrapper
+    // atual do componente, preservando o DOM em produção.
+    const stackedPosition =
+      indicatorPosition !== 'inline' ? indicatorPosition : undefined;
+
     const renderContent = () => (
       <>
         {icon && (
@@ -152,9 +170,11 @@ const ListExpandable = React.forwardRef<HTMLDivElement, ListExpandableProps>(
           caption={caption}
           inverted={inverted}
           type={status}
+          indicator={stackedPosition ? indicator : undefined}
+          indicatorPosition={stackedPosition}
         />
         <div className="ods-list-expandable__trailing">
-          {indicator && (
+          {indicator && !stackedPosition && (
             <div className="ods-list-expandable__indicator">{indicator}</div>
           )}
           <div className="ods-list-expandable__action">

--- a/packages/ocean-react/src/ListExpandable/ListExpandable.tsx
+++ b/packages/ocean-react/src/ListExpandable/ListExpandable.tsx
@@ -147,8 +147,8 @@ const ListExpandable = React.forwardRef<HTMLDivElement, ListExpandableProps>(
       </div>
     );
 
-    // Só `above`/`below` vão para dentro do ContentList; `inline` mantém o wrapper
-    // atual do componente, preservando o DOM em produção.
+    // Only `above`/`below` are passed into ContentList; `inline` keeps the component's
+    // current wrapper, preserving the production DOM.
     const stackedPosition =
       indicatorPosition !== 'inline' ? indicatorPosition : undefined;
 

--- a/packages/ocean-react/src/ListExpandable/__tests__/ListExpandable.test.tsx
+++ b/packages/ocean-react/src/ListExpandable/__tests__/ListExpandable.test.tsx
@@ -445,4 +445,76 @@ describe('ListExpandable', () => {
       ).not.toBeInTheDocument();
     });
   });
+
+  describe('indicatorPosition', () => {
+    const indicator = <span>3x sem acréscimo</span>;
+
+    test('CT-1: keeps the current wrapper when the prop is omitted', () => {
+      render(<ListExpandable title="Title" indicator={indicator} />);
+
+      const tag = screen.getByText('3x sem acréscimo');
+
+      expect(
+        tag.closest('.ods-list-expandable__indicator')
+      ).toBeInTheDocument();
+      expect(tag.closest('.ods-content-list__indicator')).toBeNull();
+    });
+
+    test('CT-4: explicit inline renders the same tree as the default', () => {
+      const { asFragment: defaultTree } = render(
+        <ListExpandable title="Title" indicator={indicator} />
+      );
+      const { asFragment: inlineTree } = render(
+        <ListExpandable
+          title="Title"
+          indicator={indicator}
+          indicatorPosition="inline"
+        />
+      );
+
+      expect(inlineTree()).toEqual(defaultTree());
+    });
+
+    test('CT-6: trailing keeps only the chevron when stacked', () => {
+      render(
+        <ListExpandable
+          title="Title"
+          indicator={indicator}
+          indicatorPosition="above"
+        />
+      );
+
+      const trailing = screen
+        .getByText('Title')
+        .closest('.ods-list-expandable')
+        ?.querySelector('.ods-list-expandable__trailing');
+
+      expect(trailing?.children).toHaveLength(1);
+      expect(trailing?.firstElementChild).toHaveClass(
+        'ods-list-expandable__action'
+      );
+      expect(
+        screen
+          .getByText('3x sem acréscimo')
+          .closest('.ods-content-list__indicator--above')
+      ).toBeInTheDocument();
+    });
+
+    test('CT-3: renders below as the last child of the content column', () => {
+      render(
+        <ListExpandable
+          title="Title"
+          caption="Caption"
+          indicator={indicator}
+          indicatorPosition="below"
+        />
+      );
+
+      const content = screen.getByText('Title').closest('.ods-content-list');
+
+      expect(content?.lastElementChild).toHaveClass(
+        'ods-content-list__indicator--below'
+      );
+    });
+  });
 });

--- a/packages/ocean-react/src/ListExpandable/stories/ListExpandable.stories.tsx
+++ b/packages/ocean-react/src/ListExpandable/stories/ListExpandable.stories.tsx
@@ -10,6 +10,11 @@ import Badge from '../../Badge';
 import Tag from '../../Tag';
 import List from '../../List';
 import Typography from '../../Typography';
+import {
+  indicatorPositionCases,
+  indicatorPositionStackStyle,
+  indicatorPositionStoryConfig,
+} from '../../_stories/components/indicatorPosition';
 
 // Mapeia os nomes dos ícones para seus componentes
 const iconMap = {
@@ -668,62 +673,13 @@ export const WithHighlight: Story = {
   ),
 };
 
-const positionIndicatorOptions = {
-  tag: <Tag type="positive">3x sem acréscimo</Tag>,
-  withoutIndicator: undefined,
-};
-
 export const IndicatorPosition: Story = {
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'The `indicatorPosition` prop sets where the `indicator` sits relative to the text. ' +
-          '`inline` (default) keeps the current behaviour — same row as the text, at the end ' +
-          'of the content block. `above` and `below` stack it inside the content block, with ' +
-          '8px of breathing room, left-aligned. The control slot never receives the indicator.',
-      },
-    },
-  },
-  argTypes: {
-    indicator: {
-      options: Object.keys(positionIndicatorOptions),
-      mapping: positionIndicatorOptions,
-      control: { type: 'radio' },
-      description:
-        'Toggles the indicator on and off in the three positions below.',
-    },
-  },
-  args: {
-    indicator: 'tag' as unknown as React.ReactNode,
-  },
+  ...indicatorPositionStoryConfig,
   render: ({ indicator }) => (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 16,
-        minWidth: 320,
-      }}
-    >
-      <ListExpandable
-        title="inline (default)"
-        description="Current behaviour — nothing changes in production"
-        indicator={indicator}
-      />
-      <ListExpandable
-        title="above"
-        description="Tag stacked above the title"
-        indicator={indicator}
-        indicatorPosition="above"
-      />
-      <ListExpandable
-        title="below"
-        description="Tag stacked below the text"
-        caption="Caption"
-        indicator={indicator}
-        indicatorPosition="below"
-      />
+    <div style={indicatorPositionStackStyle}>
+      {indicatorPositionCases.map(({ id, ...caseProps }) => (
+        <ListExpandable key={id} {...caseProps} indicator={indicator} />
+      ))}
     </div>
   ),
 };

--- a/packages/ocean-react/src/ListExpandable/stories/ListExpandable.stories.tsx
+++ b/packages/ocean-react/src/ListExpandable/stories/ListExpandable.stories.tsx
@@ -668,20 +668,36 @@ export const WithHighlight: Story = {
   ),
 };
 
+const positionIndicatorOptions = {
+  tag: <Tag type="positive">3x sem acréscimo</Tag>,
+  withoutIndicator: undefined,
+};
+
 export const IndicatorPosition: Story = {
   parameters: {
-    controls: { disable: true },
     docs: {
       description: {
         story:
-          'A prop `indicatorPosition` define onde o `indicator` fica em relação ao texto. ' +
-          '`inline` (default) mantém o comportamento atual — mesma linha do texto, no fim do ' +
-          'bloco de conteúdo. `above` e `below` empilham dentro do bloco de conteúdo, com 8px ' +
-          'de respiro e alinhados à esquerda. O slot do controle nunca recebe o indicator.',
+          'The `indicatorPosition` prop sets where the `indicator` sits relative to the text. ' +
+          '`inline` (default) keeps the current behaviour — same row as the text, at the end ' +
+          'of the content block. `above` and `below` stack it inside the content block, with ' +
+          '8px of breathing room, left-aligned. The control slot never receives the indicator.',
       },
     },
   },
-  render: () => (
+  argTypes: {
+    indicator: {
+      options: Object.keys(positionIndicatorOptions),
+      mapping: positionIndicatorOptions,
+      control: { type: 'radio' },
+      description:
+        'Toggles the indicator on and off in the three positions below.',
+    },
+  },
+  args: {
+    indicator: 'tag' as unknown as React.ReactNode,
+  },
+  render: ({ indicator }) => (
     <div
       style={{
         display: 'flex',
@@ -692,20 +708,20 @@ export const IndicatorPosition: Story = {
     >
       <ListExpandable
         title="inline (default)"
-        description="Comportamento atual — nenhuma tela em produção muda"
-        indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+        description="Current behaviour — nothing changes in production"
+        indicator={indicator}
       />
       <ListExpandable
         title="above"
-        description="Tag empilhada acima do título"
-        indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+        description="Tag stacked above the title"
+        indicator={indicator}
         indicatorPosition="above"
       />
       <ListExpandable
         title="below"
-        description="Tag empilhada abaixo do texto"
+        description="Tag stacked below the text"
         caption="Caption"
-        indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+        indicator={indicator}
         indicatorPosition="below"
       />
     </div>

--- a/packages/ocean-react/src/ListExpandable/stories/ListExpandable.stories.tsx
+++ b/packages/ocean-react/src/ListExpandable/stories/ListExpandable.stories.tsx
@@ -667,3 +667,47 @@ export const WithHighlight: Story = {
     </div>
   ),
 };
+
+export const IndicatorPosition: Story = {
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story:
+          'A prop `indicatorPosition` define onde o `indicator` fica em relação ao texto. ' +
+          '`inline` (default) mantém o comportamento atual — mesma linha do texto, no fim do ' +
+          'bloco de conteúdo. `above` e `below` empilham dentro do bloco de conteúdo, com 8px ' +
+          'de respiro e alinhados à esquerda. O slot do controle nunca recebe o indicator.',
+      },
+    },
+  },
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 16,
+        minWidth: 320,
+      }}
+    >
+      <ListExpandable
+        title="inline (default)"
+        description="Comportamento atual — nenhuma tela em produção muda"
+        indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+      />
+      <ListExpandable
+        title="above"
+        description="Tag empilhada acima do título"
+        indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+        indicatorPosition="above"
+      />
+      <ListExpandable
+        title="below"
+        description="Tag empilhada abaixo do texto"
+        caption="Caption"
+        indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+        indicatorPosition="below"
+      />
+    </div>
+  ),
+};

--- a/packages/ocean-react/src/ListReadOnly/ListReadOnly.tsx
+++ b/packages/ocean-react/src/ListReadOnly/ListReadOnly.tsx
@@ -117,8 +117,8 @@ const ListReadOnly = React.forwardRef<HTMLDivElement, ListReadOnlyProps>(
       </div>
     );
 
-    // Só `above`/`below` vão para dentro do ContentList; `inline` mantém o wrapper
-    // atual do componente, preservando o DOM em produção.
+    // Only `above`/`below` are passed into ContentList; `inline` keeps the component's
+    // current wrapper, preserving the production DOM.
     const stackedPosition =
       indicatorPosition !== 'inline' ? indicatorPosition : undefined;
 

--- a/packages/ocean-react/src/ListReadOnly/ListReadOnly.tsx
+++ b/packages/ocean-react/src/ListReadOnly/ListReadOnly.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode } from 'react';
 import classNames from 'classnames';
 import ContentList, {
   ContentListProps,
+  IndicatorPosition,
 } from '../_shared/components/ContentList';
 import SkeletonBar from '../_shared/components/SkeletonBar';
 import ListContainer, {
@@ -34,6 +35,17 @@ export type ListReadOnlyProps = {
    * Indicator/badge displayed at the end of the card.
    */
   indicator?: ReactNode;
+  /**
+   * Where the `indicator` is rendered relative to the text content.
+   *
+   * - `inline` (default): same row as the text, at the end of the content block.
+   * - `above`: stacked above the title, inside the content column.
+   * - `below`: stacked below the text, inside the content column.
+   *
+   * Has no effect when `indicator` is not provided.
+   * @default 'inline'
+   */
+  indicatorPosition?: IndicatorPosition;
   /**
    * The style type of the list item.
    * @default 'card'
@@ -84,6 +96,7 @@ const ListReadOnly = React.forwardRef<HTMLDivElement, ListReadOnlyProps>(
       caption,
       icon,
       indicator,
+      indicatorPosition = 'inline',
       type = 'card',
       status = 'default',
       inverted = false,
@@ -104,6 +117,11 @@ const ListReadOnly = React.forwardRef<HTMLDivElement, ListReadOnlyProps>(
       </div>
     );
 
+    // Só `above`/`below` vão para dentro do ContentList; `inline` mantém o wrapper
+    // atual do componente, preservando o DOM em produção.
+    const stackedPosition =
+      indicatorPosition !== 'inline' ? indicatorPosition : undefined;
+
     const renderContent = () => (
       <>
         {icon && (
@@ -122,8 +140,10 @@ const ListReadOnly = React.forwardRef<HTMLDivElement, ListReadOnlyProps>(
           caption={caption}
           inverted={inverted}
           type={status}
+          indicator={stackedPosition ? indicator : undefined}
+          indicatorPosition={stackedPosition}
         />
-        {indicator && (
+        {indicator && !stackedPosition && (
           <div className="ods-list-readonly__trailing">
             <div className="ods-list-readonly__indicator">{indicator}</div>
           </div>

--- a/packages/ocean-react/src/ListReadOnly/__tests__/ListReadOnly.test.tsx
+++ b/packages/ocean-react/src/ListReadOnly/__tests__/ListReadOnly.test.tsx
@@ -384,4 +384,75 @@ describe('CardListReadOnly', () => {
       ).not.toBeInTheDocument();
     });
   });
+
+  describe('indicatorPosition', () => {
+    const indicator = <Tag type="positive">3x sem acréscimo</Tag>;
+
+    test('CT-1: keeps the current wrappers when the prop is omitted', () => {
+      render(<ListReadOnly title="Title" indicator={indicator} />);
+
+      const tag = screen.getByText('3x sem acréscimo');
+
+      expect(tag.closest('.ods-list-readonly__indicator')).toBeInTheDocument();
+      expect(tag.closest('.ods-list-readonly__trailing')).toBeInTheDocument();
+      expect(tag.closest('.ods-content-list__indicator')).toBeNull();
+    });
+
+    test('CT-4: explicit inline renders the same tree as the default', () => {
+      const { asFragment: defaultTree } = render(
+        <ListReadOnly title="Title" indicator={indicator} />
+      );
+      const { asFragment: inlineTree } = render(
+        <ListReadOnly
+          title="Title"
+          indicator={indicator}
+          indicatorPosition="inline"
+        />
+      );
+
+      expect(inlineTree()).toEqual(defaultTree());
+    });
+
+    test('CT-7: drops the trailing wrapper and stacks above', () => {
+      render(
+        <ListReadOnly
+          title="Title"
+          indicator={indicator}
+          indicatorPosition="above"
+        />
+      );
+
+      const tag = screen.getByText('3x sem acréscimo');
+
+      expect(tag.closest('.ods-list-readonly__trailing')).toBeNull();
+      expect(
+        tag.closest('.ods-content-list__indicator--above')
+      ).toBeInTheDocument();
+    });
+
+    test('CT-3: renders below as the last child of the content column', () => {
+      render(
+        <ListReadOnly
+          title="Title"
+          caption="Caption"
+          indicator={indicator}
+          indicatorPosition="below"
+        />
+      );
+
+      const content = screen.getByText('Title').closest('.ods-content-list');
+
+      expect(content?.lastElementChild).toHaveClass(
+        'ods-content-list__indicator--below'
+      );
+    });
+
+    test('CT-11: the prop is inert without an indicator', () => {
+      render(<ListReadOnly title="Title" indicatorPosition="above" />);
+
+      const content = screen.getByText('Title').closest('.ods-content-list');
+
+      expect(content?.children).toHaveLength(1);
+    });
+  });
 });

--- a/packages/ocean-react/src/ListReadOnly/stories/ListReadOnly.stories.tsx
+++ b/packages/ocean-react/src/ListReadOnly/stories/ListReadOnly.stories.tsx
@@ -548,37 +548,53 @@ export const CompleteExample: Story = {
     ),
 };
 
+const positionIndicatorOptions = {
+  tag: <Tag type="positive">3x sem acréscimo</Tag>,
+  withoutIndicator: undefined,
+};
+
 export const IndicatorPosition: Story = {
   parameters: {
-    ...disabledControls,
     docs: {
       description: {
         story:
-          'A prop `indicatorPosition` define onde o `indicator` fica em relação ao texto. ' +
-          '`inline` (default) mantém o comportamento atual — mesma linha do texto, no fim do ' +
-          'bloco de conteúdo. `above` e `below` empilham dentro do bloco de conteúdo, com 8px ' +
-          'de respiro e alinhados à esquerda. O slot do controle nunca recebe o indicator.',
+          'The `indicatorPosition` prop sets where the `indicator` sits relative to the text. ' +
+          '`inline` (default) keeps the current behaviour — same row as the text, at the end ' +
+          'of the content block. `above` and `below` stack it inside the content block, with ' +
+          '8px of breathing room, left-aligned. The control slot never receives the indicator.',
       },
     },
   },
-  render: () => (
+  argTypes: {
+    indicator: {
+      options: Object.keys(positionIndicatorOptions),
+      mapping: positionIndicatorOptions,
+      control: { type: 'radio' },
+      description:
+        'Toggles the indicator on and off in the three positions below.',
+    },
+  },
+  args: {
+    indicator: 'tag' as unknown as React.ReactNode,
+  },
+  render: ({ indicator }) => (
     <List style={listStyle}>
       <ListReadOnly
         title="inline (default)"
-        description="Comportamento atual — nenhuma tela em produção muda"
-        indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+        description="Current behaviour — nothing changes in production"
+        indicator={indicator}
       />
       <ListReadOnly
         title="above"
-        description="Tag empilhada acima do título"
-        indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+        description="Tag stacked above the title"
+        indicator={indicator}
         indicatorPosition="above"
       />
       <ListReadOnly
         title="below"
-        description="Tag empilhada abaixo do texto"
+        description="Tag stacked below the text"
         caption="Caption"
-        indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+        indicator={indicator}
         indicatorPosition="below"
       />
     </List>

--- a/packages/ocean-react/src/ListReadOnly/stories/ListReadOnly.stories.tsx
+++ b/packages/ocean-react/src/ListReadOnly/stories/ListReadOnly.stories.tsx
@@ -547,3 +547,40 @@ export const CompleteExample: Story = {
       { icon: defaultIcon }
     ),
 };
+
+export const IndicatorPosition: Story = {
+  parameters: {
+    ...disabledControls,
+    docs: {
+      description: {
+        story:
+          'A prop `indicatorPosition` define onde o `indicator` fica em relação ao texto. ' +
+          '`inline` (default) mantém o comportamento atual — mesma linha do texto, no fim do ' +
+          'bloco de conteúdo. `above` e `below` empilham dentro do bloco de conteúdo, com 8px ' +
+          'de respiro e alinhados à esquerda. O slot do controle nunca recebe o indicator.',
+      },
+    },
+  },
+  render: () => (
+    <List style={listStyle}>
+      <ListReadOnly
+        title="inline (default)"
+        description="Comportamento atual — nenhuma tela em produção muda"
+        indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+      />
+      <ListReadOnly
+        title="above"
+        description="Tag empilhada acima do título"
+        indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+        indicatorPosition="above"
+      />
+      <ListReadOnly
+        title="below"
+        description="Tag empilhada abaixo do texto"
+        caption="Caption"
+        indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+        indicatorPosition="below"
+      />
+    </List>
+  ),
+};

--- a/packages/ocean-react/src/ListReadOnly/stories/ListReadOnly.stories.tsx
+++ b/packages/ocean-react/src/ListReadOnly/stories/ListReadOnly.stories.tsx
@@ -6,6 +6,10 @@ import type { ListReadOnlyProps } from '../ListReadOnly';
 import Badge from '../../Badge';
 import Tag from '../../Tag';
 import List from '../../List';
+import {
+  indicatorPositionCases,
+  indicatorPositionStoryConfig,
+} from '../../_stories/components/indicatorPosition';
 
 const defaultIcon = <PlaceholderOutline size={24} />;
 const listStyle = { minWidth: '300px' };
@@ -548,55 +552,13 @@ export const CompleteExample: Story = {
     ),
 };
 
-const positionIndicatorOptions = {
-  tag: <Tag type="positive">3x sem acréscimo</Tag>,
-  withoutIndicator: undefined,
-};
-
 export const IndicatorPosition: Story = {
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'The `indicatorPosition` prop sets where the `indicator` sits relative to the text. ' +
-          '`inline` (default) keeps the current behaviour — same row as the text, at the end ' +
-          'of the content block. `above` and `below` stack it inside the content block, with ' +
-          '8px of breathing room, left-aligned. The control slot never receives the indicator.',
-      },
-    },
-  },
-  argTypes: {
-    indicator: {
-      options: Object.keys(positionIndicatorOptions),
-      mapping: positionIndicatorOptions,
-      control: { type: 'radio' },
-      description:
-        'Toggles the indicator on and off in the three positions below.',
-    },
-  },
-  args: {
-    indicator: 'tag' as unknown as React.ReactNode,
-  },
+  ...indicatorPositionStoryConfig,
   render: ({ indicator }) => (
     <List style={listStyle}>
-      <ListReadOnly
-        title="inline (default)"
-        description="Current behaviour — nothing changes in production"
-        indicator={indicator}
-      />
-      <ListReadOnly
-        title="above"
-        description="Tag stacked above the title"
-        indicator={indicator}
-        indicatorPosition="above"
-      />
-      <ListReadOnly
-        title="below"
-        description="Tag stacked below the text"
-        caption="Caption"
-        indicator={indicator}
-        indicatorPosition="below"
-      />
+      {indicatorPositionCases.map(({ id, ...caseProps }) => (
+        <ListReadOnly key={id} {...caseProps} indicator={indicator} />
+      ))}
     </List>
   ),
 };

--- a/packages/ocean-react/src/ListSelectable/ListSelectable.tsx
+++ b/packages/ocean-react/src/ListSelectable/ListSelectable.tsx
@@ -113,8 +113,8 @@ const ListSelectable = React.forwardRef<HTMLDivElement, ListSelectableProps>(
       [radio?.disabled, checkbox?.disabled, disabled]
     );
 
-    // Só `above`/`below` vão para dentro do ContentList; `inline` mantém o wrapper
-    // atual do componente, preservando o DOM em produção.
+    // Only `above`/`below` are passed into ContentList; `inline` keeps the component's
+    // current wrapper, preserving the production DOM.
     const stackedPosition =
       indicatorPosition !== 'inline' ? indicatorPosition : undefined;
 

--- a/packages/ocean-react/src/ListSelectable/ListSelectable.tsx
+++ b/packages/ocean-react/src/ListSelectable/ListSelectable.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode, useMemo } from 'react';
 import classNames from 'classnames';
 import ContentList, {
   ContentListProps,
+  IndicatorPosition,
 } from '../_shared/components/ContentList/ContentList';
 import Checkbox, { CheckboxProps } from '../Checkbox/Checkbox';
 import Radio, { RadioProps } from '../Radio/Radio';
@@ -37,6 +38,17 @@ interface ListSelectableBaseProps {
   showDivider?: boolean;
   /** Optional visual indicator element (Badge, Tag, etc.). */
   indicator?: ReactNode;
+  /**
+   * Where the `indicator` is rendered relative to the text content.
+   *
+   * - `inline` (default): same row as the text, at the end of the content block.
+   * - `above`: stacked above the title, inside the content column.
+   * - `below`: stacked below the text, inside the content column.
+   *
+   * Has no effect when `indicator` is not provided.
+   * @default 'inline'
+   */
+  indicatorPosition?: IndicatorPosition;
   /** Visual state applied to the text content (`default`, `warning`, etc.). */
   status?: ContentListProps['type'];
   /** Platform context used to adjust spacing (web or app). */
@@ -63,7 +75,9 @@ type ListSelectableTextProps = ListSelectableBaseProps & {
   cornerTag?: never;
 };
 
-type ListSelectableProps = ListSelectableCardProps | ListSelectableTextProps;
+export type ListSelectableProps =
+  | ListSelectableCardProps
+  | ListSelectableTextProps;
 
 const ListSelectable = React.forwardRef<HTMLDivElement, ListSelectableProps>(
   (props, ref) => {
@@ -80,6 +94,7 @@ const ListSelectable = React.forwardRef<HTMLDivElement, ListSelectableProps>(
       className,
       showDivider,
       indicator,
+      indicatorPosition = 'inline',
       isSelectableDisabled,
       highlight,
       status = 'default',
@@ -98,6 +113,11 @@ const ListSelectable = React.forwardRef<HTMLDivElement, ListSelectableProps>(
       [radio?.disabled, checkbox?.disabled, disabled]
     );
 
+    // Só `above`/`below` vão para dentro do ContentList; `inline` mantém o wrapper
+    // atual do componente, preservando o DOM em produção.
+    const stackedPosition =
+      indicatorPosition !== 'inline' ? indicatorPosition : undefined;
+
     const internalList = useMemo(
       () => (
         <>
@@ -108,8 +128,10 @@ const ListSelectable = React.forwardRef<HTMLDivElement, ListSelectableProps>(
             caption={caption}
             inverted={inverted}
             type={disabled ? 'inactive' : status}
+            indicator={stackedPosition ? indicator : undefined}
+            indicatorPosition={stackedPosition}
           />
-          {indicator && (
+          {indicator && !stackedPosition && (
             <div
               className={classNames('ods-list-selectable__indicator', {
                 [`ods-list-selectable__indicator--${platform}`]: platform,
@@ -128,6 +150,7 @@ const ListSelectable = React.forwardRef<HTMLDivElement, ListSelectableProps>(
         inverted,
         status,
         indicator,
+        stackedPosition,
         disabled,
         platform,
       ]
@@ -155,6 +178,7 @@ const ListSelectable = React.forwardRef<HTMLDivElement, ListSelectableProps>(
           className={className}
           showDivider={showDivider}
           indicator={indicator}
+          indicatorPosition={indicatorPosition}
           caption={caption}
           strikethroughDescription={strikethroughDescription}
           highlight={highlight}

--- a/packages/ocean-react/src/ListSelectable/__tests__/ListSelectable.test.tsx
+++ b/packages/ocean-react/src/ListSelectable/__tests__/ListSelectable.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 import ListSelectable from '../ListSelectable';
 
@@ -20,10 +20,7 @@ describe('ListSelectable — basic rendering', () => {
 
   test('renders with radio controller', () => {
     render(
-      <ListSelectable
-        title="Title"
-        radio={{ id: 'r-1', name: 'group' }}
-      />
+      <ListSelectable title="Title" radio={{ id: 'r-1', name: 'group' }} />
     );
 
     expect(screen.getByRole('radio')).toBeInTheDocument();
@@ -31,11 +28,7 @@ describe('ListSelectable — basic rendering', () => {
 
   test('shows skeleton when loading (title is hidden)', () => {
     render(
-      <ListSelectable
-        title="Title"
-        loading
-        checkbox={{ id: 'cb-loading' }}
-      />
+      <ListSelectable title="Title" loading checkbox={{ id: 'cb-loading' }} />
     );
 
     expect(screen.queryByText('Title')).not.toBeInTheDocument();
@@ -92,11 +85,7 @@ describe('ListSelectable — cornerTag (V-02 to V-14)', () => {
 
   test('V-05: does NOT render Corner Tag when type=text', () => {
     render(
-      <ListSelectable
-        type="text"
-        title="Title"
-        checkbox={{ id: 'cb-text' }}
-      />
+      <ListSelectable type="text" title="Title" checkbox={{ id: 'cb-text' }} />
     );
 
     expect(screen.queryByText('Recomendado')).not.toBeInTheDocument();
@@ -231,4 +220,194 @@ describe('ListSelectable — cornerTag (V-02 to V-14)', () => {
 
     expect(screen.getByText('ReadOnly')).toBeInTheDocument();
   });
+});
+
+describe('ListSelectable — indicatorPosition', () => {
+  const indicator = <span>3x sem acréscimo</span>;
+
+  test('CT-1: keeps the current wrapper when the prop is omitted', () => {
+    render(
+      <ListSelectable
+        title="Title"
+        indicator={indicator}
+        checkbox={{ id: 'cb-default' }}
+      />
+    );
+
+    const tag = screen.getByText('3x sem acréscimo');
+
+    expect(tag.closest('.ods-list-selectable__indicator')).toBeInTheDocument();
+    expect(tag.closest('.ods-content-list__indicator')).toBeNull();
+  });
+
+  test('CT-4: explicit inline renders the same tree as the default', () => {
+    const { asFragment: defaultTree } = render(
+      <ListSelectable
+        title="Title"
+        indicator={indicator}
+        checkbox={{ id: 'cb-a' }}
+      />
+    );
+    const { asFragment: inlineTree } = render(
+      <ListSelectable
+        title="Title"
+        indicator={indicator}
+        indicatorPosition="inline"
+        checkbox={{ id: 'cb-a' }}
+      />
+    );
+
+    expect(inlineTree()).toEqual(defaultTree());
+  });
+
+  test('CT-2: renders above as the first child of the content column', () => {
+    render(
+      <ListSelectable
+        title="Title"
+        description="Description"
+        indicator={indicator}
+        indicatorPosition="above"
+        radio={{ id: 'r-above', name: 'group' }}
+      />
+    );
+
+    const content = screen.getByText('Title').closest('.ods-content-list');
+
+    expect(content?.firstElementChild).toHaveClass(
+      'ods-content-list__indicator--above'
+    );
+    expect(
+      screen
+        .getByText('3x sem acréscimo')
+        .closest('.ods-list-selectable__indicator')
+    ).toBeNull();
+  });
+
+  test('CT-4 (trailing): the input is untouched when stacked', () => {
+    render(
+      <ListSelectable
+        title="Title"
+        indicator={indicator}
+        indicatorPosition="below"
+        radio={{ id: 'r-below', name: 'group' }}
+      />
+    );
+
+    expect(screen.getByRole('radio')).toBeInTheDocument();
+    expect(
+      screen
+        .getByText('3x sem acréscimo')
+        .closest('.ods-content-list__indicator--below')
+    ).toBeInTheDocument();
+  });
+
+  test('CT-8: forwards the position to ListReadOnly when isSelectableDisabled', () => {
+    render(
+      <ListSelectable
+        title="Title"
+        indicator={indicator}
+        indicatorPosition="above"
+        isSelectableDisabled
+        checkbox={{ id: 'cb-disabled' }}
+      />
+    );
+
+    const tag = screen.getByText('3x sem acréscimo');
+
+    expect(screen.getByTestId('card-list-readonly')).toBeInTheDocument();
+    expect(
+      tag.closest('.ods-content-list__indicator--above')
+    ).toBeInTheDocument();
+    expect(tag.closest('.ods-list-readonly__trailing')).toBeNull();
+  });
+
+  test('CT-9: re-rendering with a new position updates the DOM', () => {
+    const { rerender } = render(
+      <ListSelectable
+        title="Title"
+        indicator={indicator}
+        indicatorPosition="inline"
+        checkbox={{ id: 'cb-rerender' }}
+      />
+    );
+
+    expect(
+      screen
+        .getByText('3x sem acréscimo')
+        .closest('.ods-list-selectable__indicator')
+    ).toBeInTheDocument();
+
+    rerender(
+      <ListSelectable
+        title="Title"
+        indicator={indicator}
+        indicatorPosition="above"
+        checkbox={{ id: 'cb-rerender' }}
+      />
+    );
+
+    const tag = screen.getByText('3x sem acréscimo');
+
+    expect(tag.closest('.ods-list-selectable__indicator')).toBeNull();
+    expect(
+      tag.closest('.ods-content-list__indicator--above')
+    ).toBeInTheDocument();
+  });
+
+  test('CT-11: the prop is inert without an indicator', () => {
+    render(
+      <ListSelectable
+        title="Title"
+        indicatorPosition="above"
+        checkbox={{ id: 'cb-noind' }}
+      />
+    );
+
+    const content = screen.getByText('Title').closest('.ods-content-list');
+
+    expect(content?.children).toHaveLength(1);
+  });
+});
+
+describe('ListSelectable — clicking the indicator toggles selection (CT-14)', () => {
+  const positions = ['inline', 'above', 'below'] as const;
+
+  test.each(positions)(
+    'checkbox toggles when clicking the indicator (%s)',
+    (position) => {
+      const onChange = jest.fn();
+
+      render(
+        <ListSelectable
+          title="Title"
+          indicator={<span>3x sem acréscimo</span>}
+          indicatorPosition={position}
+          checkbox={{ id: `cb-click-${position}`, onChange }}
+        />
+      );
+
+      fireEvent.click(screen.getByText('3x sem acréscimo'));
+
+      expect(screen.getByRole('checkbox')).toBeChecked();
+      expect(onChange).toHaveBeenCalled();
+    }
+  );
+
+  test.each(positions)(
+    'radio selects when clicking the indicator (%s)',
+    (position) => {
+      render(
+        <ListSelectable
+          title="Title"
+          indicator={<span>3x sem acréscimo</span>}
+          indicatorPosition={position}
+          radio={{ id: `r-click-${position}`, name: `g-${position}` }}
+        />
+      );
+
+      fireEvent.click(screen.getByText('3x sem acréscimo'));
+
+      expect(screen.getByRole('radio')).toBeChecked();
+    }
+  );
 });

--- a/packages/ocean-react/src/ListSelectable/index.ts
+++ b/packages/ocean-react/src/ListSelectable/index.ts
@@ -1,1 +1,2 @@
 export { default } from './ListSelectable';
+export type { ListSelectableProps } from './ListSelectable';

--- a/packages/ocean-react/src/ListSelectable/stories/ListSelectable.stories.tsx
+++ b/packages/ocean-react/src/ListSelectable/stories/ListSelectable.stories.tsx
@@ -748,3 +748,50 @@ export const WithHighlight: Story = {
     </div>
   ),
 };
+
+export const IndicatorPosition: Story = {
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story:
+          'A prop `indicatorPosition` define onde o `indicator` fica em relação ao texto. ' +
+          '`inline` (default) mantém o comportamento atual — mesma linha do texto, no fim do ' +
+          'bloco de conteúdo. `above` e `below` empilham dentro do bloco de conteúdo, com 8px ' +
+          'de respiro e alinhados à esquerda. O slot do controle nunca recebe o indicator.',
+      },
+    },
+  },
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 16,
+        minWidth: 320,
+      }}
+    >
+      <ListSelectable
+        title="inline (default)"
+        description="Comportamento atual — nenhuma tela em produção muda"
+        indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+        radio={{ id: 'ip-inline', name: 'indicator-position' }}
+      />
+      <ListSelectable
+        title="above"
+        description="Tag empilhada acima do título"
+        indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+        indicatorPosition="above"
+        radio={{ id: 'ip-above', name: 'indicator-position' }}
+      />
+      <ListSelectable
+        title="below"
+        description="Tag empilhada abaixo do texto"
+        caption="Caption"
+        indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+        indicatorPosition="below"
+        radio={{ id: 'ip-below', name: 'indicator-position' }}
+      />
+    </div>
+  ),
+};

--- a/packages/ocean-react/src/ListSelectable/stories/ListSelectable.stories.tsx
+++ b/packages/ocean-react/src/ListSelectable/stories/ListSelectable.stories.tsx
@@ -749,20 +749,36 @@ export const WithHighlight: Story = {
   ),
 };
 
+const positionIndicatorOptions = {
+  tag: <Tag type="positive">3x sem acréscimo</Tag>,
+  withoutIndicator: undefined,
+};
+
 export const IndicatorPosition: Story = {
   parameters: {
-    controls: { disable: true },
     docs: {
       description: {
         story:
-          'A prop `indicatorPosition` define onde o `indicator` fica em relação ao texto. ' +
-          '`inline` (default) mantém o comportamento atual — mesma linha do texto, no fim do ' +
-          'bloco de conteúdo. `above` e `below` empilham dentro do bloco de conteúdo, com 8px ' +
-          'de respiro e alinhados à esquerda. O slot do controle nunca recebe o indicator.',
+          'The `indicatorPosition` prop sets where the `indicator` sits relative to the text. ' +
+          '`inline` (default) keeps the current behaviour — same row as the text, at the end ' +
+          'of the content block. `above` and `below` stack it inside the content block, with ' +
+          '8px of breathing room, left-aligned. The control slot never receives the indicator.',
       },
     },
   },
-  render: () => (
+  argTypes: {
+    indicator: {
+      options: Object.keys(positionIndicatorOptions),
+      mapping: positionIndicatorOptions,
+      control: { type: 'radio' },
+      description:
+        'Toggles the indicator on and off in the three positions below.',
+    },
+  },
+  args: {
+    indicator: 'tag' as unknown as React.ReactNode,
+  },
+  render: ({ indicator }) => (
     <div
       style={{
         display: 'flex',
@@ -773,22 +789,22 @@ export const IndicatorPosition: Story = {
     >
       <ListSelectable
         title="inline (default)"
-        description="Comportamento atual — nenhuma tela em produção muda"
-        indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+        description="Current behaviour — nothing changes in production"
+        indicator={indicator}
         radio={{ id: 'ip-inline', name: 'indicator-position' }}
       />
       <ListSelectable
         title="above"
-        description="Tag empilhada acima do título"
-        indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+        description="Tag stacked above the title"
+        indicator={indicator}
         indicatorPosition="above"
         radio={{ id: 'ip-above', name: 'indicator-position' }}
       />
       <ListSelectable
         title="below"
-        description="Tag empilhada abaixo do texto"
+        description="Tag stacked below the text"
         caption="Caption"
-        indicator={<Tag type="positive">3x sem acréscimo</Tag>}
+        indicator={indicator}
         indicatorPosition="below"
         radio={{ id: 'ip-below', name: 'indicator-position' }}
       />

--- a/packages/ocean-react/src/ListSelectable/stories/ListSelectable.stories.tsx
+++ b/packages/ocean-react/src/ListSelectable/stories/ListSelectable.stories.tsx
@@ -5,6 +5,11 @@ import Tag from '../../Tag';
 import ListSelectable from '../ListSelectable';
 
 import List from '../../List';
+import {
+  indicatorPositionCases,
+  indicatorPositionStackStyle,
+  indicatorPositionStoryConfig,
+} from '../../_stories/components/indicatorPosition';
 
 const storyStyles = {
   container: {
@@ -749,65 +754,18 @@ export const WithHighlight: Story = {
   ),
 };
 
-const positionIndicatorOptions = {
-  tag: <Tag type="positive">3x sem acréscimo</Tag>,
-  withoutIndicator: undefined,
-};
-
 export const IndicatorPosition: Story = {
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'The `indicatorPosition` prop sets where the `indicator` sits relative to the text. ' +
-          '`inline` (default) keeps the current behaviour — same row as the text, at the end ' +
-          'of the content block. `above` and `below` stack it inside the content block, with ' +
-          '8px of breathing room, left-aligned. The control slot never receives the indicator.',
-      },
-    },
-  },
-  argTypes: {
-    indicator: {
-      options: Object.keys(positionIndicatorOptions),
-      mapping: positionIndicatorOptions,
-      control: { type: 'radio' },
-      description:
-        'Toggles the indicator on and off in the three positions below.',
-    },
-  },
-  args: {
-    indicator: 'tag' as unknown as React.ReactNode,
-  },
+  ...indicatorPositionStoryConfig,
   render: ({ indicator }) => (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 16,
-        minWidth: 320,
-      }}
-    >
-      <ListSelectable
-        title="inline (default)"
-        description="Current behaviour — nothing changes in production"
-        indicator={indicator}
-        radio={{ id: 'ip-inline', name: 'indicator-position' }}
-      />
-      <ListSelectable
-        title="above"
-        description="Tag stacked above the title"
-        indicator={indicator}
-        indicatorPosition="above"
-        radio={{ id: 'ip-above', name: 'indicator-position' }}
-      />
-      <ListSelectable
-        title="below"
-        description="Tag stacked below the text"
-        caption="Caption"
-        indicator={indicator}
-        indicatorPosition="below"
-        radio={{ id: 'ip-below', name: 'indicator-position' }}
-      />
+    <div style={indicatorPositionStackStyle}>
+      {indicatorPositionCases.map(({ id, ...caseProps }) => (
+        <ListSelectable
+          key={id}
+          {...caseProps}
+          indicator={indicator}
+          radio={{ id: `ip-${id}`, name: 'indicator-position' }}
+        />
+      ))}
     </div>
   ),
 };

--- a/packages/ocean-react/src/_shared/components/ContentList/ContentList.tsx
+++ b/packages/ocean-react/src/_shared/components/ContentList/ContentList.tsx
@@ -1,5 +1,15 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import classNames from 'classnames';
+
+/**
+ * Where the indicator is rendered relative to the text content.
+ *
+ * - `inline` (default): keeps each component's current position — same row as the text,
+ *   at the end of the content block.
+ * - `above`: stacked above the title, inside the content column.
+ * - `below`: stacked below the text, inside the content column.
+ */
+export type IndicatorPosition = 'inline' | 'above' | 'below';
 
 export type ContentListProps = {
   title: string;
@@ -15,6 +25,13 @@ export type ContentListProps = {
     | 'highlight'
     | 'highlight-lead'
     | 'strikethrough';
+  /**
+   * Indicator stacked inside the content column. Only set by the host component when
+   * `indicatorPosition` is `above` or `below` — `inline` keeps the host's own wrapper.
+   */
+  indicator?: ReactNode;
+  /** Stacking side of `indicator`. Ignored when `indicator` is not provided. */
+  indicatorPosition?: Exclude<IndicatorPosition, 'inline'>;
 };
 
 const ContentList = ({
@@ -24,50 +41,67 @@ const ContentList = ({
   caption,
   inverted = false,
   type = 'default',
-}: ContentListProps): ReactElement => (
-  <div className="ods-content-list">
-    <p
-      className={classNames('ods-typography', {
-        'ods-typography__paragraph': !inverted,
-        'ods-typography__description': inverted,
-        [`ods-typography__paragraph--${type}`]:
-          type && (!inverted || type === 'inactive'),
-      })}
-    >
-      {strikethroughDescription && type === 'strikethrough' && !inverted && (
-        <span className="ods-typography__paragraph--strikethrough-text">
-          {strikethroughDescription}
-        </span>
+  indicator,
+  indicatorPosition,
+}: ContentListProps): ReactElement => {
+  const stackedIndicator = indicator && indicatorPosition && (
+    <div
+      className={classNames(
+        'ods-content-list__indicator',
+        `ods-content-list__indicator--${indicatorPosition}`
       )}
-      {title}
-    </p>
-    {description && (
+    >
+      {indicator}
+    </div>
+  );
+
+  return (
+    <div className="ods-content-list">
+      {indicatorPosition === 'above' && stackedIndicator}
       <p
-        className={classNames(`ods-typography`, {
-          'ods-typography__description': !inverted,
-          'ods-typography__paragraph': inverted,
+        className={classNames('ods-typography', {
+          'ods-typography__paragraph': !inverted,
+          'ods-typography__description': inverted,
           [`ods-typography__paragraph--${type}`]:
-            type && (inverted || type === 'inactive'),
+            type && (!inverted || type === 'inactive'),
         })}
       >
-        {strikethroughDescription && type === 'strikethrough' && inverted && (
+        {strikethroughDescription && type === 'strikethrough' && !inverted && (
           <span className="ods-typography__paragraph--strikethrough-text">
             {strikethroughDescription}
           </span>
         )}
-        {description}
+        {title}
       </p>
-    )}
-    {caption && (
-      <p
-        className={classNames(`ods-typography ods-typography__captionbold`, {
-          [`ods-typography__paragraph--${type}`]: type && type === 'inactive',
-        })}
-      >
-        {caption}
-      </p>
-    )}
-  </div>
-);
+      {description && (
+        <p
+          className={classNames(`ods-typography`, {
+            'ods-typography__description': !inverted,
+            'ods-typography__paragraph': inverted,
+            [`ods-typography__paragraph--${type}`]:
+              type && (inverted || type === 'inactive'),
+          })}
+        >
+          {strikethroughDescription && type === 'strikethrough' && inverted && (
+            <span className="ods-typography__paragraph--strikethrough-text">
+              {strikethroughDescription}
+            </span>
+          )}
+          {description}
+        </p>
+      )}
+      {caption && (
+        <p
+          className={classNames(`ods-typography ods-typography__captionbold`, {
+            [`ods-typography__paragraph--${type}`]: type && type === 'inactive',
+          })}
+        >
+          {caption}
+        </p>
+      )}
+      {indicatorPosition === 'below' && stackedIndicator}
+    </div>
+  );
+};
 
 export default ContentList;

--- a/packages/ocean-react/src/_shared/components/ContentList/__tests__/ContentList.test.tsx
+++ b/packages/ocean-react/src/_shared/components/ContentList/__tests__/ContentList.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ContentList from '../ContentList';
+
+describe('ContentList', () => {
+  describe('Basic Rendering', () => {
+    test('renders the title', () => {
+      render(<ContentList title="Test Title" />);
+
+      expect(screen.getByText('Test Title')).toBeInTheDocument();
+    });
+
+    test('renders description and caption when provided', () => {
+      render(
+        <ContentList
+          title="Title"
+          description="Description"
+          caption="Caption"
+        />
+      );
+
+      expect(screen.getByText('Description')).toBeInTheDocument();
+      expect(screen.getByText('Caption')).toBeInTheDocument();
+    });
+
+    test('does not render description or caption when omitted', () => {
+      render(<ContentList title="Title" />);
+
+      const content = screen.getByText('Title').closest('.ods-content-list');
+
+      expect(content?.children).toHaveLength(1);
+    });
+  });
+
+  describe('indicator slot', () => {
+    const indicator = <span data-testid="indicator">Tag</span>;
+
+    test('does not render the indicator when position is not provided', () => {
+      render(<ContentList title="Title" indicator={indicator} />);
+
+      const content = screen.getByText('Title').closest('.ods-content-list');
+
+      expect(screen.queryByTestId('indicator')).not.toBeInTheDocument();
+      expect(content?.children).toHaveLength(1);
+    });
+
+    test('does not render a wrapper when position is set without indicator', () => {
+      render(<ContentList title="Title" indicatorPosition="above" />);
+
+      const content = screen.getByText('Title').closest('.ods-content-list');
+
+      expect(content?.children).toHaveLength(1);
+    });
+
+    test('renders the indicator as the first child when position is above', () => {
+      render(
+        <ContentList
+          title="Title"
+          description="Description"
+          caption="Caption"
+          indicator={indicator}
+          indicatorPosition="above"
+        />
+      );
+
+      const content = screen
+        .getByText('Title')
+        .closest('.ods-content-list') as HTMLElement;
+      const wrapper = content.firstElementChild as HTMLElement;
+
+      expect(wrapper).toHaveClass('ods-content-list__indicator');
+      expect(wrapper).toHaveClass('ods-content-list__indicator--above');
+      expect(wrapper).toContainElement(screen.getByTestId('indicator'));
+    });
+
+    test('renders the indicator as the last child when position is below', () => {
+      render(
+        <ContentList
+          title="Title"
+          description="Description"
+          caption="Caption"
+          indicator={indicator}
+          indicatorPosition="below"
+        />
+      );
+
+      const content = screen
+        .getByText('Title')
+        .closest('.ods-content-list') as HTMLElement;
+      const wrapper = content.lastElementChild as HTMLElement;
+
+      expect(wrapper).toHaveClass('ods-content-list__indicator');
+      expect(wrapper).toHaveClass('ods-content-list__indicator--below');
+      expect(wrapper).toContainElement(screen.getByTestId('indicator'));
+    });
+
+    test('keeps title, description and caption in order around the indicator', () => {
+      render(
+        <ContentList
+          title="Title"
+          description="Description"
+          caption="Caption"
+          indicator={indicator}
+          indicatorPosition="above"
+        />
+      );
+
+      const content = screen
+        .getByText('Title')
+        .closest('.ods-content-list') as HTMLElement;
+      const texts = Array.from(content.children).map((child) =>
+        child.textContent?.trim()
+      );
+
+      expect(texts).toEqual(['Tag', 'Title', 'Description', 'Caption']);
+    });
+  });
+});

--- a/packages/ocean-react/src/_shared/components/ContentList/index.ts
+++ b/packages/ocean-react/src/_shared/components/ContentList/index.ts
@@ -1,2 +1,2 @@
 export { default } from './ContentList';
-export type { ContentListProps } from './ContentList';
+export type { ContentListProps, IndicatorPosition } from './ContentList';

--- a/packages/ocean-react/src/_stories/components/indicatorPosition.tsx
+++ b/packages/ocean-react/src/_stories/components/indicatorPosition.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import Tag from '../../Tag';
+
+/**
+ * Shared pieces of the `IndicatorPosition` story, used by ListAction, ListExpandable,
+ * ListReadOnly and ListSelectable. Kept here so the four stories do not repeat the same
+ * parameters, argTypes and cases.
+ *
+ * This folder is excluded from the published build (see `tsconfig.build.json`).
+ */
+
+const indicatorOptions = {
+  tag: <Tag type="positive">3x sem acréscimo</Tag>,
+  withoutIndicator: undefined,
+};
+
+export const indicatorPositionStackStyle = {
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: 16,
+  minWidth: 320,
+};
+
+/** `parameters`, `argTypes` and `args` shared by the four stories. */
+export const indicatorPositionStoryConfig = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The `indicatorPosition` prop sets where the `indicator` sits relative to the ' +
+          'text. `inline` (default) keeps the current behaviour — same row as the text, at ' +
+          'the end of the content block. `above` and `below` stack it inside the content ' +
+          'block, with 8px of breathing room, left-aligned. The control slot never receives ' +
+          'the indicator.',
+      },
+    },
+  },
+  argTypes: {
+    indicator: {
+      options: Object.keys(indicatorOptions),
+      mapping: indicatorOptions,
+      control: { type: 'radio' as const },
+      description:
+        'Toggles the indicator on and off in the three positions below.',
+    },
+  },
+  args: {
+    indicator: 'tag' as unknown as React.ReactNode,
+  },
+};
+
+/** One entry per position, in the order they are shown. */
+export const indicatorPositionCases = [
+  {
+    id: 'inline',
+    title: 'inline (default)',
+    description: 'Current behaviour — nothing changes in production',
+  },
+  {
+    id: 'above',
+    title: 'above',
+    description: 'Tag stacked above the title',
+    indicatorPosition: 'above' as const,
+  },
+  {
+    id: 'below',
+    title: 'below',
+    description: 'Tag stacked below the text',
+    caption: 'Caption',
+    indicatorPosition: 'below' as const,
+  },
+];


### PR DESCRIPTION
## Contexto

A tela de seleção de benefícios do PagBlu ([MR-523](https://useblu.atlassian.net/browse/MR-523)) posiciona a tag `%{installments}x sem acréscimo` **acima do título** do card. Hoje a posição do `indicator` é fixa no CSS de cada componente, então a tela sairia com layout montado por fora e o DS deixaria de ser a fonte da verdade.

Subtarefa **MR-553** de [MR-552](https://useblu.atlassian.net/browse/MR-552). Spec: [Ledger](https://github.com/Pagnet/product-bluprints/blob/main/prd-tracking/MR-552-indicator-position/MR-552-indicator-position-ledger.md).

## São dois commits — o segundo é o único visível a cliente

### 1. `feat(list)` — o enabler, zero mudança visual

`ListAction`, `ListExpandable`, `ListReadOnly` e `ListSelectable` ganham:

```ts
indicatorPosition?: 'inline' | 'above' | 'below'  // default 'inline'
```

**Um ponto compartilhado, não quatro.** Os 4 já renderizam `ContentList`, e `.ods-content-list` já é a coluna de conteúdo (`display:flex; flex-direction:column; flex:1`) — exatamente o container que o design pede. O `ContentList` ganhou um slot opcional de indicator e o SCSS ganhou `__indicator` com `--above`/`--below`. Em `inline` nada é passado e o host mantém o wrapper atual, byte a byte.

Os 8px do respiro vão no `margin` do wrapper, **nunca em `gap` do `.ods-content-list`**: o container não tem `gap` hoje e o espaçamento entre título, descrição e caption vem do `margin-top` do caption — um `gap` ali regrediria os 9 componentes que usam o `ContentList`.

Dois detalhes que o `ListSelectable` exigia e são fáceis de passar batido:

- `indicatorPosition` entra nas **deps do `useMemo`** do `internalList`, senão a posição fica obsoleta ao trocar a prop em runtime (coberto por teste);
- a posição é **repassada ao `ListReadOnly`** no ramo `isSelectableDisabled`, senão se perde exatamente no estado desabilitado (coberto por teste).

Também exporta `ListSelectableProps` no barrel — a doc já instruía esse import e ele **não existia**.

### 2. `fix(list-expandable)` — ⚠️ mudança visual em produção

`.ods-list-expandable__main { gap }` de **12px para 8px**, acompanhando o Figma (itemSpacing do frame Main de 12 → 8, bound a `spacingXxs`, nas 18 variantes).

**Toda tela que usa o `ListExpandable` verá o ícone 4px mais perto do texto.** Raio medido por busca de código: **4 usos, todos em `mfe-charge-management`** — drawer de uso de crédito da rede, detalhes de saldo, drawer de cobrança da rede e banner de status de portabilidade.

Deixa o DS **temporariamente inconsistente**: 8px no `ListExpandable` contra 12px em `ListAction`, `ListReadOnly` e `ListSettings` — espelhando o Figma, onde os outros 7 componentes ainda não foram tocados.

Está isolado num commit próprio de propósito: se a mudança visual não for agora, **dropa o commit** e o enabler segue.

## Verificação

| | |
|---|---|
| Suíte completa | **781 testes, 66 suítes — todos passando** |
| Snapshots | **115, todos inalterados** — é a prova automática de que `inline` não mexeu em produção |
| Testes novos | **35**, incluindo teste próprio do `ContentList` (que não tinha nenhum) |
| Não-regressão do blast radius | `ListSettings`, `SettingsListItem` e `TransactionListExpandable` — os 3 consumidores do `ContentList` fora deste escopo |
| Clique | `ListSelectable`: clicar no indicator alterna checkbox/radio **nas 3 posições** (não havia teste de clique nesse componente) |
| Lint | `eslint` com **0 erros** |

Cada teste referencia o cenário da spec (CT-1 a CT-14). Os de `CT-4` comparam `asFragment()` entre o default e o `inline` explícito — se divergirem, a retrocompatibilidade quebrou.

## Storybook e doc

Story `IndicatorPosition` nos 4 componentes com as 3 posições lado a lado (alimenta o Chromatic), e seção nova no `.mdx` de cada um. No `ListAction` a doc distingue explicitamente `indicatorPosition` de `position` (timeline) e `menuPosition` (dropdown).

## Nota sobre `inline`

`inline` significa **ao lado do texto, no fim do bloco de conteúdo** — a posição que os quatro já produzem hoje. A estrutura interna varia (em `ListExpandable`/`ListReadOnly` o indicator vive dentro de `__trailing`), mas a ordem visual renderizada é **texto → tag → controle** nos quatro, garantida por `.ods-content-list { flex: 1 }`. O indicator pertence ao bloco de conteúdo, não ao slot do controle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ocean-ds/ocean-web/pull/1253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->